### PR TITLE
Call ensureIndexes from constructors instead of @PostConstruct

### DIFF
--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngine.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngine.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.annotation.PostConstruct;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -64,6 +63,7 @@ public class MongoEventStorageEngine extends BatchingEventStorageEngine {
         super(builder);
         this.template = builder.template;
         this.storageStrategy = builder.storageStrategy;
+        ensureIndexes();
     }
 
     /**
@@ -95,8 +95,12 @@ public class MongoEventStorageEngine extends BatchingEventStorageEngine {
 
     /**
      * Make sure an index is created on the collection that stores domain events.
+     *
+     * @deprecated  This method is now called by the constructor instead of the dependency injection framework running
+     *              the @PostConstruct. i.e. You no longer have to call it manually if you don't use a dependency
+     *              injection framework.
      */
-    @PostConstruct
+    @Deprecated
     public void ensureIndexes() {
         storageStrategy.ensureIndexes(template.eventCollection(), template.snapshotCollection());
     }

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStore.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStore.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import javax.annotation.PostConstruct;
 
 import static com.mongodb.client.model.Filters.*;
 import static com.mongodb.client.model.Projections.*;
@@ -92,6 +91,7 @@ public class MongoTokenStore implements TokenStore {
         this.claimTimeout = builder.claimTimeout;
         this.nodeId = builder.nodeId;
         this.contentType = builder.contentType;
+        ensureIndexes();
     }
 
     /**
@@ -307,8 +307,12 @@ public class MongoTokenStore implements TokenStore {
 
     /**
      * Creates the indexes required to work with the TokenStore.
+     *
+     * @deprecated  This method is now called by the constructor instead of the dependency injection framework running
+     *              the @PostConstruct. i.e. You no longer have to call it manually if you don't use a dependency
+     *              injection framework.
      */
-    @PostConstruct
+    @Deprecated
     public void ensureIndexes() {
         mongoTemplate.trackingTokensCollection().createIndex(Indexes.ascending("processorName", "segment"),
                                                              new IndexOptions().unique(true));

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
@@ -92,10 +92,8 @@ public class MongoEventStorageEngineTest extends AbstractMongoEventStorageEngine
         mongoTemplate.snapshotCollection().dropIndexes();
         mongoTemplate.eventCollection().deleteMany(new BasicDBObject());
         mongoTemplate.snapshotCollection().deleteMany(new BasicDBObject());
-        testSubject = context.getBean(MongoEventStorageEngine.class);
+        testSubject = MongoEventStorageEngine.builder().mongoTemplate(mongoTemplate).build();
         setTestSubject(testSubject);
-
-        testSubject.ensureIndexes();
     }
 
     @Test

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
@@ -107,7 +107,6 @@ public class MongoTokenStoreTest {
                                                                    .claimTimeout(claimTimeout)
                                                                    .contentType(contentType);
         tokenStore = tokenStoreBuilder.nodeId(testOwner).build();
-        tokenStore.ensureIndexes();
         tokenStoreDifferentOwner = tokenStoreBuilder.nodeId("anotherOwner").build();
     }
 


### PR DESCRIPTION
This allows the use of MongoTokenStore in a non-dependency-injected
environment without shifting the burden of initialization onto the
programmer. This is particularly important because of the unintended
event replays which can occur if the @PostConstruct call is not called
manually.

Mirrors the change in 3.4.x: AxonFramework issue [#974](https://github.com/AxonFramework/AxonFramework/pull/974)