### PR TITLE
[#3] Update Mongo Token Store implementation

### DIFF
--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStore.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStore.java
@@ -130,7 +130,8 @@ public class MongoTokenStore implements TokenStore {
 
         if (updateResult.getModifiedCount() == 0) {
             throw new UnableToClaimTokenException(format(
-                    "Unable to claim token '%s[%s]'. It has not been initialized yet", processorName, segment
+                    "Unable to claim token '%s[%s]'. It is either already claimed or it does not exist",
+                    processorName, segment
             ));
         }
     }


### PR DESCRIPTION
This pull request updates the `MongoTokenStore` such that it implements the `initializeSegment(TrackingToken, String, int)`, `deleteToken(String, int)` and `requiresExplicitSegmentInitialization()` methods. Doing so makes it possible to leverage the [split and merge](https://github.com/AxonFramework/AxonFramework/pull/969) functionality as was introduced in Axon Framework release 4.1 whilst using the `MongoTokenStore`.

This PR resolves #3