### PR TITLE
Upgraded to MongoDb java driver 4.0.3

### DIFF
--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.mongo</groupId>
         <artifactId>axon-mongo-parent</artifactId>
-        <version>4.3</version>
+        <version>4.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-mongo</artifactId>

--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -50,8 +50,8 @@
         <!-- Mongo dependencies -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>3.3.0</version>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.0.3</version>
         </dependency>
 
         <!-- Jackson dependencies -->

--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.0.3</version>
+            <version>${mongo.driver.version}</version>
         </dependency>
 
         <!-- Jackson dependencies -->

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/AbstractMongoTemplate.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/AbstractMongoTemplate.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extensions.mongo;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import org.axonframework.common.AxonConfigurationException;
 

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/DefaultMongoTemplate.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/DefaultMongoTemplate.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extensions.mongo;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.axonframework.common.AxonConfigurationException;

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactory.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactory.java
@@ -18,21 +18,15 @@ package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.ServerAddress;
-import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoClients;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Convenience class for creating Mongo instances. It helps configuring a Mongo instance with a WriteConcern safe to use
  * in combination with the given server addresses.
  * <p/>
- * Depending on the number of addresses provided, the factory defaults to either {@link WriteConcern#W2} when
- * more than one address is provided, or {@link WriteConcern#JOURNALED} when only one server is available. The idea of
- * these defaults is that data must be able to survive a (not too heavy) crash without loss of data. We wouldn't want to
- * publish untraceable events, would we...
+ *
+ * Upgrade note: Upon upgrading the MongoDb driver version from  3.x to 4.x, write concerns were moved to MongoOptionsFactory.
+ * @see MongoSettingsFactory
  *
  * @author Jettro Coenradie
  * @since 2.0 (in incubator since 0.7)
@@ -57,7 +51,7 @@ public class MongoFactory {
      *
      * @param mongoOptions MongoOptions to overrule the default
      */
-    public void setMongoOptions(MongoClientSettings mongoOptions) {
+    public void setMongoClientSettings(MongoClientSettings mongoOptions) {
         this.mongoOptions = mongoOptions;
     }
 

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactory.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactory.java
@@ -16,10 +16,11 @@
 
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
+import com.mongodb.client.MongoClient;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoClients;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,8 +29,8 @@ import java.util.List;
  * Convenience class for creating Mongo instances. It helps configuring a Mongo instance with a WriteConcern safe to use
  * in combination with the given server addresses.
  * <p/>
- * Depending on the number of addresses provided, the factory defaults to either {@link WriteConcern#REPLICAS_SAFE} when
- * more than one address is provided, or {@link WriteConcern#FSYNC_SAFE} when only one server is available. The idea of
+ * Depending on the number of addresses provided, the factory defaults to either {@link WriteConcern#W2} when
+ * more than one address is provided, or {@link WriteConcern#JOURNALED} when only one server is available. The idea of
  * these defaults is that data must be able to survive a (not too heavy) crash without loss of data. We wouldn't want to
  * publish untraceable events, would we...
  *
@@ -38,9 +39,7 @@ import java.util.List;
  */
 public class MongoFactory {
 
-    private List<ServerAddress> mongoAddresses = Collections.emptyList();
-    private MongoClientOptions mongoOptions = MongoClientOptions.builder().build();
-    private WriteConcern writeConcern;
+    private MongoClientSettings mongoOptions = MongoClientSettings.builder().build();
 
     /**
      * Creates a mongo instance based on the provided configuration. Read javadoc of the class to learn about the
@@ -49,29 +48,7 @@ public class MongoFactory {
      * @return a new Mongo instance each time this method is called.
      */
     public MongoClient createMongo() {
-        MongoClient mongo;
-        if (mongoAddresses.isEmpty()) {
-            mongo = new MongoClient(new ServerAddress(), mongoOptions);
-        } else {
-            mongo = new MongoClient(mongoAddresses, mongoOptions);
-        }
-        mongo.setWriteConcern(defaultWriteConcern());
-
-        return mongo;
-    }
-
-    /**
-     * Provide a list of ServerAddress objects to use for locating the Mongo replica set. An empty list will result in
-     * a single Mongo instance being used on the default host ({@code 127.0.0.1}) and port
-     * (<code>{@code com.mongodb.ServerAddress#defaultPort}</code>)
-     * <p/>
-     * Defaults to an empty list, which locates a single Mongo instance on the default host ({@code 127.0.0.1})
-     * and port <code>({@code com.mongodb.ServerAddress#defaultPort})</code>
-     *
-     * @param mongoAddresses List of ServerAddress instances
-     */
-    public void setMongoAddresses(List<ServerAddress> mongoAddresses) {
-        this.mongoAddresses = mongoAddresses;
+        return MongoClients.create(mongoOptions);
     }
 
     /**
@@ -80,36 +57,8 @@ public class MongoFactory {
      *
      * @param mongoOptions MongoOptions to overrule the default
      */
-    public void setMongoOptions(MongoClientOptions mongoOptions) {
+    public void setMongoOptions(MongoClientSettings mongoOptions) {
         this.mongoOptions = mongoOptions;
     }
 
-    /**
-     * Provided a write concern to be used by the mongo instance. The provided concern should be compatible with the
-     * number of addresses provided with {@link #setMongoAddresses(java.util.List)}. For example, providing
-     * {@link WriteConcern#REPLICAS_SAFE} in combination with a single address will cause each write operation to hang.
-     * <p/>
-     * While safe (e.g. {@link WriteConcern#REPLICAS_SAFE}) WriteConcerns allow you to detect concurrency issues
-     * immediately, you might want to use a more relaxed write concern if you have other mechanisms in place to ensure
-     * consistency.
-     * <p/>
-     * Defaults to {@link WriteConcern#REPLICAS_SAFE} if you provided more than one address with
-     * {@link #setMongoAddresses(java.util.List)}, or {@link WriteConcern#FSYNC_SAFE} if there is only one address (or
-     * none at all).
-     *
-     * @param writeConcern WriteConcern to use for the connections
-     */
-    public void setWriteConcern(WriteConcern writeConcern) {
-        this.writeConcern = writeConcern;
-    }
-
-    private WriteConcern defaultWriteConcern() {
-        if (writeConcern != null) {
-            return this.writeConcern;
-        } else if (mongoAddresses.size() > 1) {
-            return WriteConcern.REPLICAS_SAFE;
-        } else {
-            return WriteConcern.FSYNC_SAFE;
-        }
-    }
 }

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactory.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactory.java
@@ -33,7 +33,7 @@ import com.mongodb.client.MongoClients;
  */
 public class MongoFactory {
 
-    private MongoClientSettings mongoOptions = MongoClientSettings.builder().build();
+    private MongoClientSettings mongoClientSettings = MongoClientSettings.builder().build();
 
     /**
      * Creates a mongo instance based on the provided configuration. Read javadoc of the class to learn about the
@@ -42,17 +42,17 @@ public class MongoFactory {
      * @return a new Mongo instance each time this method is called.
      */
     public MongoClient createMongo() {
-        return MongoClients.create(mongoOptions);
+        return MongoClients.create(mongoClientSettings);
     }
 
     /**
-     * Provide an instance of MongoOptions to be used for the connections. Defaults to a MongoOptions with all its
+     * Provide an instance of MongoClientSettings to be used for the connections. Defaults to a MongoClientSettings with all its
      * default settings.
      *
-     * @param mongoOptions MongoOptions to overrule the default
+     * @param mongoClientSettings MongoClientSettings to overrule the default
      */
-    public void setMongoClientSettings(MongoClientSettings mongoOptions) {
-        this.mongoOptions = mongoOptions;
+    public void setMongoClientSettings(MongoClientSettings mongoClientSettings) {
+        this.mongoClientSettings = mongoClientSettings;
     }
 
 }

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactory.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactory.java
@@ -65,7 +65,7 @@ public class MongoSettingsFactory {
      *
      * @return MongoOptions instance based on the configured properties
      */
-    public MongoClientSettings createMongoOptions() {
+    public MongoClientSettings createMongoClientSettings() {
         MongoClientSettings settings = MongoClientSettings.builder()
                 .applyToConnectionPoolSettings(builder -> builder.maxWaitTime(getMaxWaitTime(), TimeUnit.MILLISECONDS).maxSize(getConnectionsPerHost()))
                 .applyToClusterSettings(builder -> builder.hosts(mongoAddresses))
@@ -156,30 +156,6 @@ public class MongoSettingsFactory {
         this.socketTimeOut = socketTimeOut;
     }
 
-    /**
-     * Getter for the amount of threads that block in relation to the amount of possible connections.
-     *
-     * @return Number representing the multiplier of maximum allowed blocked connections in relation to the maximum
-     *         allowed connections
-     * @deprecated in the next major release, wait queue size limitations will be removed
-     */
-//    public int getThreadsAllowedToBlockForConnectionMultiplier() {
-//        return (threadsAllowedToBlockForConnectionMultiplier > 0)
-//                ? threadsAllowedToBlockForConnectionMultiplier
-//                : defaults.getThreadsAllowedToBlockForConnectionMultiplier();
-//    }
-
-    /**
-     * Set the multiplier for the amount of threads to block in relation to the maximum amount of connections.
-     *
-     * @param threadsAllowedToBlockForConnectionMultiplier
-     *            Number representing the multiplier of the amount of threads to block in relation to the connections
-     *            that are allowed.
-     * @deprecated in the next major release, wait queue size limitations will be removed
-     */
-//    public void setThreadsAllowedToBlockForConnectionMultiplier(int threadsAllowedToBlockForConnectionMultiplier) {
-//        this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;
-//    }
     /**
      * Provide a list of ServerAddress objects to use for locating the Mongo replica set. An empty list will result in
      * a single Mongo instance being used on the default host ({@code 127.0.0.1}) and port

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactory.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactory.java
@@ -16,13 +16,9 @@
 
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
-import com.mongodb.Block;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
-import com.mongodb.connection.ClusterSettings;
-import com.mongodb.connection.ConnectionPoolSettings;
-import com.mongodb.connection.SocketSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,16 +28,22 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * <p>
- * Factory class used to create a {@code MongoOptions} instance. The instance makes use of the defaults as provided
+ * Factory class used to create a {@code MongoClientSettings} instance. The instance makes use of the defaults as provided
  * by the MongoOptions class. The moment you set a valid value, that value is used to create the options object.
  * </p>
+ *
+ * Note: WriteConcern enums were changed in MongoDb driver 4.x.
+ * Depending on the number of addresses provided, the factory defaults to either {@link WriteConcern#W2} when
+ * more than one address is provided, or {@link WriteConcern#JOURNALED} when only one server is available. The idea of
+ * these defaults is that data must be able to survive a (not too heavy) crash without loss of data. We wouldn't want to
+ * publish untraceable events, would we...
  *
  * @author Jettro Coenradie
  * @since 2.0 (in incubator since 0.7)
  */
-public class MongoOptionsFactory {
+public class MongoSettingsFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(MongoOptionsFactory.class);
+    private static final Logger logger = LoggerFactory.getLogger(MongoSettingsFactory.class);
 
     private final MongoClientSettings defaults;
     private List<ServerAddress> mongoAddresses = Collections.emptyList();
@@ -49,13 +51,12 @@ public class MongoOptionsFactory {
     private int connectionsPerHost;
     private int connectionTimeout;
     private long maxWaitTime;
-    private int threadsAllowedToBlockForConnectionMultiplier;
     private int socketTimeOut;
 
     /**
      * Default constructor for the factory that initializes the defaults.
      */
-    public MongoOptionsFactory() {
+    public MongoSettingsFactory() {
         defaults = MongoClientSettings.builder().build();
     }
 

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/serialization/DBObjectToStringContentTypeConverter.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/serialization/DBObjectToStringContentTypeConverter.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.extensions.mongo.serialization;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
 import org.axonframework.serialization.ContentTypeConverter;
 
 /**
@@ -41,6 +41,7 @@ public class DBObjectToStringContentTypeConverter implements ContentTypeConverte
 
     @Override
     public String convert(DBObject original) {
-        return JSON.serialize(original);
+        // TODO assuming this is BasicDbObject always
+        return ((BasicDBObject)original).toJson();
     }
 }

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/serialization/StringToDBObjectContentTypeConverter.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/serialization/StringToDBObjectContentTypeConverter.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.extensions.mongo.serialization;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
 import org.axonframework.serialization.ContentTypeConverter;
 
 /**
@@ -41,6 +41,6 @@ public class StringToDBObjectContentTypeConverter implements ContentTypeConverte
 
     @Override
     public DBObject convert(String original) {
-        return (DBObject) JSON.parse(original);
+        return BasicDBObject.parse(original);
     }
 }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/DefaultMongoTemplateTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/DefaultMongoTemplateTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extensions.mongo;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/MongoTestContext.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/MongoTestContext.java
@@ -4,7 +4,7 @@ import com.mongodb.client.MongoClient;
 import org.axonframework.extensions.mongo.eventhandling.saga.repository.MongoSagaStore;
 import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoEventStorageEngine;
 import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoFactory;
-import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoOptionsFactory;
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoSettingsFactory;
 import org.axonframework.spring.saga.SpringResourceInjector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,15 +31,15 @@ public class MongoTestContext {
     }
 
     @Bean
-    public MongoFactory mongoFactoryBean(MongoOptionsFactory mongoOptionsFactory) {
+    public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoOptionsFactory) {
         MongoFactory mongoFactory = new MongoFactory();
-        mongoFactory.setMongoOptions(mongoOptionsFactory.createMongoOptions());
+        mongoFactory.setMongoClientSettings(mongoOptionsFactory.createMongoOptions());
         return mongoFactory;
     }
 
     @Bean
-    public MongoOptionsFactory mongoOptionsFactory() {
-        MongoOptionsFactory mongoOptionsFactory = new MongoOptionsFactory();
+    public MongoSettingsFactory mongoOptionsFactory() {
+        MongoSettingsFactory mongoOptionsFactory = new MongoSettingsFactory();
         mongoOptionsFactory.setConnectionsPerHost(100);
         return mongoOptionsFactory;
     }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/MongoTestContext.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/MongoTestContext.java
@@ -31,14 +31,14 @@ public class MongoTestContext {
     }
 
     @Bean
-    public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoOptionsFactory) {
+    public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoSettingsFactory) {
         MongoFactory mongoFactory = new MongoFactory();
-        mongoFactory.setMongoClientSettings(mongoOptionsFactory.createMongoOptions());
+        mongoFactory.setMongoClientSettings(mongoSettingsFactory.createMongoClientSettings());
         return mongoFactory;
     }
 
     @Bean
-    public MongoSettingsFactory mongoOptionsFactory() {
+    public MongoSettingsFactory mongoSettingsFactory() {
         MongoSettingsFactory mongoOptionsFactory = new MongoSettingsFactory();
         mongoOptionsFactory.setConnectionsPerHost(100);
         return mongoOptionsFactory;

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/MongoTestContext.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/MongoTestContext.java
@@ -1,6 +1,6 @@
 package org.axonframework.extensions.mongo;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import org.axonframework.extensions.mongo.eventhandling.saga.repository.MongoSagaStore;
 import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoEventStorageEngine;
 import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoFactory;

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/saga/repository/MongoSagaStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/saga/repository/MongoSagaStoreTest.java
@@ -16,9 +16,9 @@
 
 package org.axonframework.extensions.mongo.eventhandling.saga.repository;
 
-import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClients;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import org.axonframework.extensions.mongo.DefaultMongoTemplate;
@@ -80,7 +80,11 @@ class MongoSagaStoreTest {
         mongod = mongoExe.start();
         if (mongod == null) {
             // we're using an existing mongo instance. Make sure it's clean
-            DefaultMongoTemplate template = DefaultMongoTemplate.builder().mongoDatabase(new MongoClient()).build();
+            MongoClient mongoClient = MongoClients.create();
+            DefaultMongoTemplate template = DefaultMongoTemplate
+                    .builder()
+                    .mongoDatabase(mongoClient)
+                    .build();
             template.eventCollection().drop();
             template.snapshotCollection().drop();
         }
@@ -99,7 +103,7 @@ class MongoSagaStoreTest {
     @BeforeEach
     void setUp() {
         try {
-            context.getBean(Mongo.class);
+            context.getBean(MongoClient.class);
             context.getBean(MongoEventStorageEngine.class);
         } catch (Exception e) {
             assumeTrue(true, "No Mongo instance found. Ignoring test.");

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
@@ -17,7 +17,7 @@
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
@@ -105,7 +105,7 @@ class MongoEventStorageEngineTest extends AbstractMongoEventStorageEngineTest {
         testSubject.storeSnapshot(createEvent(1));
         testSubject.storeSnapshot(createEvent(2));
 
-        assertEquals(1, mongoTemplate.snapshotCollection().count());
+        assertEquals(1, mongoTemplate.snapshotCollection().countDocuments());
     }
 
     @Test

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
@@ -17,7 +17,7 @@
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.WriteConcern;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
@@ -162,7 +162,7 @@ class MongoEventStorageEngineTest_DBObjectSerialization extends AbstractMongoEve
         public MongoFactory mongoFactoryBean(MongoOptionsFactory mongoOptionsFactory) {
             MongoFactory mongoFactory = new MongoFactory();
             mongoFactory.setMongoOptions(mongoOptionsFactory.createMongoOptions());
-            mongoFactory.setWriteConcern(WriteConcern.JOURNALED);
+
             return mongoFactory;
         }
 
@@ -170,6 +170,7 @@ class MongoEventStorageEngineTest_DBObjectSerialization extends AbstractMongoEve
         public MongoOptionsFactory mongoOptionsFactory() {
             MongoOptionsFactory mongoOptionsFactory = new MongoOptionsFactory();
             mongoOptionsFactory.setConnectionsPerHost(100);
+            mongoOptionsFactory.setWriteConcern(WriteConcern.JOURNALED);
             return mongoOptionsFactory;
         }
 

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
@@ -159,19 +159,19 @@ class MongoEventStorageEngineTest_DBObjectSerialization extends AbstractMongoEve
         }
 
         @Bean
-        public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoOptionsFactory) {
+        public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoSettingsFactory) {
             MongoFactory mongoFactory = new MongoFactory();
-            mongoFactory.setMongoClientSettings(mongoOptionsFactory.createMongoOptions());
+            mongoFactory.setMongoClientSettings(mongoSettingsFactory.createMongoClientSettings());
 
             return mongoFactory;
         }
 
         @Bean
-        public MongoSettingsFactory mongoOptionsFactory() {
-            MongoSettingsFactory mongoOptionsFactory = new MongoSettingsFactory();
-            mongoOptionsFactory.setConnectionsPerHost(100);
-            mongoOptionsFactory.setWriteConcern(WriteConcern.JOURNALED);
-            return mongoOptionsFactory;
+        public MongoSettingsFactory mongoSettingsFactory() {
+            MongoSettingsFactory mongoSettingsFactory = new MongoSettingsFactory();
+            mongoSettingsFactory.setConnectionsPerHost(100);
+            mongoSettingsFactory.setWriteConcern(WriteConcern.JOURNALED);
+            return mongoSettingsFactory;
         }
 
         @Bean

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DBObjectSerialization.java
@@ -159,16 +159,16 @@ class MongoEventStorageEngineTest_DBObjectSerialization extends AbstractMongoEve
         }
 
         @Bean
-        public MongoFactory mongoFactoryBean(MongoOptionsFactory mongoOptionsFactory) {
+        public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoOptionsFactory) {
             MongoFactory mongoFactory = new MongoFactory();
-            mongoFactory.setMongoOptions(mongoOptionsFactory.createMongoOptions());
+            mongoFactory.setMongoClientSettings(mongoOptionsFactory.createMongoOptions());
 
             return mongoFactory;
         }
 
         @Bean
-        public MongoOptionsFactory mongoOptionsFactory() {
-            MongoOptionsFactory mongoOptionsFactory = new MongoOptionsFactory();
+        public MongoSettingsFactory mongoOptionsFactory() {
+            MongoSettingsFactory mongoOptionsFactory = new MongoSettingsFactory();
             mongoOptionsFactory.setConnectionsPerHost(100);
             mongoOptionsFactory.setWriteConcern(WriteConcern.JOURNALED);
             return mongoOptionsFactory;

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
@@ -17,7 +17,7 @@
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
@@ -276,15 +276,15 @@ class MongoEventStorageEngineTest_DocPerCommit extends AbstractMongoEventStorage
         }
 
         @Bean
-        public MongoFactory mongoFactoryBean(MongoOptionsFactory mongoOptionsFactory) {
+        public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoOptionsFactory) {
             MongoFactory mongoFactory = new MongoFactory();
-            mongoFactory.setMongoOptions(mongoOptionsFactory.createMongoOptions());
+            mongoFactory.setMongoClientSettings(mongoOptionsFactory.createMongoOptions());
             return mongoFactory;
         }
 
         @Bean
-        public MongoOptionsFactory mongoOptionsFactory() {
-            MongoOptionsFactory mongoOptionsFactory = new MongoOptionsFactory();
+        public MongoSettingsFactory mongoOptionsFactory() {
+            MongoSettingsFactory mongoOptionsFactory = new MongoSettingsFactory();
             mongoOptionsFactory.setConnectionsPerHost(100);
             return mongoOptionsFactory;
         }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest_DocPerCommit.java
@@ -276,17 +276,17 @@ class MongoEventStorageEngineTest_DocPerCommit extends AbstractMongoEventStorage
         }
 
         @Bean
-        public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoOptionsFactory) {
+        public MongoFactory mongoFactoryBean(MongoSettingsFactory mongoSettingsFactory) {
             MongoFactory mongoFactory = new MongoFactory();
-            mongoFactory.setMongoClientSettings(mongoOptionsFactory.createMongoOptions());
+            mongoFactory.setMongoClientSettings(mongoSettingsFactory.createMongoClientSettings());
             return mongoFactory;
         }
 
         @Bean
-        public MongoSettingsFactory mongoOptionsFactory() {
-            MongoSettingsFactory mongoOptionsFactory = new MongoSettingsFactory();
-            mongoOptionsFactory.setConnectionsPerHost(100);
-            return mongoOptionsFactory;
+        public MongoSettingsFactory mongoSettingsFactory() {
+            MongoSettingsFactory mongoSettingsFactory = new MongoSettingsFactory();
+            mongoSettingsFactory.setConnectionsPerHost(100);
+            return mongoSettingsFactory;
         }
 
         @Bean

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactoryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoFactoryTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
-import com.mongodb.Mongo;
+import com.mongodb.client.MongoClient;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,7 +31,7 @@ class MongoFactoryTest {
     @Test
     void createMongoInstance() {
         MongoFactory mongoFactory = new MongoFactory();
-        Mongo mongoInstance = mongoFactory.createMongo();
+        MongoClient mongoInstance = mongoFactory.createMongo();
 
         assertNotNull(mongoInstance);
     }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoOptionsFactoryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoOptionsFactoryTest.java
@@ -16,8 +16,10 @@
 
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
-import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientSettings;
 import org.junit.jupiter.api.*;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -37,15 +39,17 @@ class MongoOptionsFactoryTest {
 
     @Test
     void testCreateMongoOptions_defaults() {
-        MongoClientOptions options = factory.createMongoOptions();
-        MongoClientOptions defaults = MongoClientOptions.builder().build();
+        MongoClientSettings options = factory.createMongoOptions();
+        MongoClientSettings defaults = MongoClientSettings.builder().build();
 
-        assertEquals(defaults.getMaxWaitTime(), options.getMaxWaitTime());
-        assertEquals(defaults.getSocketTimeout(), options.getSocketTimeout());
-        assertEquals(defaults.getConnectionsPerHost(), options.getConnectionsPerHost());
-        assertEquals(defaults.getConnectTimeout(), options.getConnectTimeout());
-        assertEquals(defaults.getThreadsAllowedToBlockForConnectionMultiplier(),
-                     options.getThreadsAllowedToBlockForConnectionMultiplier());
+        assertEquals(defaults.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS), options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
+        assertEquals(defaults.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS), options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
+        assertEquals(defaults.getConnectionPoolSettings().getMaxSize(), options.getConnectionPoolSettings().getMaxSize());
+        // TODO connect time and socket timeout is identical
+//        assertEquals(defaults.getConnectTimeout(), options.getConnectTimeout());
+        // TODO deprecated
+//        assertEquals(defaults.getThreadsAllowedToBlockForConnectionMultiplier(),
+//                     options.getThreadsAllowedToBlockForConnectionMultiplier());
     }
 
     @Test
@@ -54,13 +58,16 @@ class MongoOptionsFactoryTest {
         factory.setConnectionTimeout(11);
         factory.setMaxWaitTime(3);
         factory.setSocketTimeOut(23);
-        factory.setThreadsAllowedToBlockForConnectionMultiplier(31);
+//        factory.setThreadsAllowedToBlockForConnectionMultiplier(31);
 
-        MongoClientOptions options = factory.createMongoOptions();
-        assertEquals(3, options.getMaxWaitTime());
-        assertEquals(23, options.getSocketTimeout());
-        assertEquals(9, options.getConnectionsPerHost());
-        assertEquals(11, options.getConnectTimeout());
-        assertEquals(31, options.getThreadsAllowedToBlockForConnectionMultiplier());
+        MongoClientSettings options = factory.createMongoOptions();
+        assertEquals(3, options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
+        assertEquals(23, options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
+        assertEquals(9, options.getConnectionPoolSettings().getMaxSize());
+
+        // TODO connect time and socket timeout is identical
+//        assertEquals(11, options.getConnectTimeout());
+        // TODO deprecated
+//        assertEquals(31, options.getThreadsAllowedToBlockForConnectionMultiplier());
     }
 }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactoryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactoryTest.java
@@ -39,7 +39,7 @@ class MongoSettingsFactoryTest {
 
     @Test
     void testCreateMongoClientSettings_defaults() {
-        MongoClientSettings options = factory.createMongoOptions();
+        MongoClientSettings options = factory.createMongoClientSettings();
         MongoClientSettings defaults = MongoClientSettings.builder().build();
 
         assertEquals(defaults.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS), options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
@@ -53,7 +53,7 @@ class MongoSettingsFactoryTest {
         factory.setMaxWaitTime(3);
         factory.setSocketTimeOut(23);
 
-        MongoClientSettings options = factory.createMongoOptions();
+        MongoClientSettings options = factory.createMongoClientSettings();
         assertEquals(3, options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
         assertEquals(23, options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
         assertEquals(9, options.getConnectionPoolSettings().getMaxSize());

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactoryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactoryTest.java
@@ -49,13 +49,14 @@ class MongoSettingsFactoryTest {
     @Test
     void testCreateMongoClientSettings_customSet() {
         factory.setConnectionsPerHost(9);
-        factory.setConnectionTimeout(11);
+        factory.setSocketConnectTimeout(11);
         factory.setMaxWaitTime(3);
-        factory.setSocketTimeOut(23);
+        factory.setSocketReadTimeOut(23);
 
         MongoClientSettings options = factory.createMongoClientSettings();
         assertEquals(3, options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
-        assertEquals(23, options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
+        assertEquals(11, options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
+        assertEquals(23, options.getSocketSettings().getReadTimeout(TimeUnit.MILLISECONDS));
         assertEquals(9, options.getConnectionPoolSettings().getMaxSize());
     }
 }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactoryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoSettingsFactoryTest.java
@@ -24,50 +24,38 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test class validating the {@link MongoOptionsFactory}.
+ * Test class validating the {@link MongoSettingsFactory}.
  *
  * @author Jettro Coenradie
  */
-class MongoOptionsFactoryTest {
+class MongoSettingsFactoryTest {
 
-    private MongoOptionsFactory factory;
+    private MongoSettingsFactory factory;
 
     @BeforeEach
     void setUp() {
-        factory = new MongoOptionsFactory();
+        factory = new MongoSettingsFactory();
     }
 
     @Test
-    void testCreateMongoOptions_defaults() {
+    void testCreateMongoClientSettings_defaults() {
         MongoClientSettings options = factory.createMongoOptions();
         MongoClientSettings defaults = MongoClientSettings.builder().build();
 
         assertEquals(defaults.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS), options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
         assertEquals(defaults.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS), options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
-        assertEquals(defaults.getConnectionPoolSettings().getMaxSize(), options.getConnectionPoolSettings().getMaxSize());
-        // TODO connect time and socket timeout is identical
-//        assertEquals(defaults.getConnectTimeout(), options.getConnectTimeout());
-        // TODO deprecated
-//        assertEquals(defaults.getThreadsAllowedToBlockForConnectionMultiplier(),
-//                     options.getThreadsAllowedToBlockForConnectionMultiplier());
     }
 
     @Test
-    void testCreateMongoOptions_customSet() {
+    void testCreateMongoClientSettings_customSet() {
         factory.setConnectionsPerHost(9);
         factory.setConnectionTimeout(11);
         factory.setMaxWaitTime(3);
         factory.setSocketTimeOut(23);
-//        factory.setThreadsAllowedToBlockForConnectionMultiplier(31);
 
         MongoClientSettings options = factory.createMongoOptions();
         assertEquals(3, options.getConnectionPoolSettings().getMaxWaitTime(TimeUnit.MILLISECONDS));
         assertEquals(23, options.getSocketSettings().getConnectTimeout(TimeUnit.MILLISECONDS));
         assertEquals(9, options.getConnectionPoolSettings().getMaxSize());
-
-        // TODO connect time and socket timeout is identical
-//        assertEquals(11, options.getConnectTimeout());
-        // TODO deprecated
-//        assertEquals(31, options.getThreadsAllowedToBlockForConnectionMultiplier());
     }
 }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.extensions.mongo.eventsourcing.tokenstore;
 
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import de.flapdoodle.embed.mongo.MongodExecutable;

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <axon.version>4.3.1</axon.version>
-
         <spring.version>5.1.4.RELEASE</spring.version>
 
         <slf4j.version>1.7.28</slf4j.version>
@@ -119,6 +118,8 @@
         <commons-io.version>2.6</commons-io.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.jaxb-api.version>2.3.0</javax.jaxb-api.version>
+
+        <mongo.driver.version>4.0.3</mongo.driver.version>
     </properties>
 
     <dependencies>
@@ -405,13 +406,6 @@
     </build>
 
     <repositories>
-        <!-- Maven repository -->
-<!--        <repository>-->
-<!--            <id>maven</id>-->
-<!--            <name>Maven repo</name>-->
-<!--            <url>https://repo.maven.apache.org/maven2/</url>-->
-<!--        </repository>-->
-
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.axonframework.extensions.mongo</groupId>
     <artifactId>axon-mongo-parent</artifactId>
-    <version>4.3</version>
+    <version>4.4-SNAPSHOT</version>
     <modules>
         <module>mongo</module>
     </modules>
@@ -428,7 +428,7 @@
         <connection>scm:git:git://github.com/AxonFramework/extension-mongo.git</connection>
         <developerConnection>scm:git:git@github.com:AxonFramework/extension-mongo.git</developerConnection>
         <url>https://github.com/AxonFramework/extension-mongo</url>
-        <tag>axon-mongo-4.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,13 @@
     </build>
 
     <repositories>
+        <!-- Maven repository -->
+<!--        <repository>-->
+<!--            <id>maven</id>-->
+<!--            <name>Maven repo</name>-->
+<!--            <url>https://repo.maven.apache.org/maven2/</url>-->
+<!--        </repository>-->
+
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>


### PR DESCRIPTION
Here's a PR with support for the latest MongoDb Java driver 4.0.3. I noted @deprecated or added a TODO wherever necessary.

Note, this is not backwards compatible.

Please have a look. If all good, would love to get a release of this so I can upgrade to Spring Boot 2.3.0 :-)

Cheers,
Bjorn