### PR TITLE
Axon Mongo Example module

### DIFF
--- a/mongo-axon-example/README.md
+++ b/mongo-axon-example/README.md
@@ -1,7 +1,8 @@
 # Mongo Axon Springboot Example
 
-This is an example SpringBoot application using the Mongo Axon extension.
-It uses the Mongo as the Event Store and Token Store as well.
+This is an example SpringBoot application using the Mongo Axon extension. It uses Mongo as the Event- and Token Store.
+
+> Although Mongodb might be a good fit for it, we have encountered some inefficiencies in regards to the Mongo Event Store implementation that you can read more about [here](https://docs.axoniq.io/reference-guide/extensions/mongo)
 
 ## How to run
 

--- a/mongo-axon-example/README.md
+++ b/mongo-axon-example/README.md
@@ -1,0 +1,31 @@
+# Mongo Axon Springboot Example
+
+This is an example SpringBoot application using the Mongo Axon extension.
+It uses the Mongo as the Event Store and Token Store as well.
+
+## How to run
+
+### Preparation
+
+You will need `docker` and `docker-compose` to run this example.
+
+Please run:
+
+```bash
+docker-compose -f ./mongo-axon-example/docker-compose.yaml up -d
+```
+
+This will start Mongo with default values.
+
+Now build the application by running:
+
+```bash
+mvn clean package -f ./mongo-axon-example
+```
+
+### Running example application
+
+You can start the application by running `java -jar ./mongo-axon-example/target/mongo-axon-example.jar`.
+
+You can access the mongo-express UI on [http://localhost:8081/db/axonframework/](http://localhost:8081/db/axonframework/)
+where you can see the tables used by axon and inspect events, tokens and snapshots.

--- a/mongo-axon-example/docker-compose.yaml
+++ b/mongo-axon-example/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+
+  mongo:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081

--- a/mongo-axon-example/pom.xml
+++ b/mongo-axon-example/pom.xml
@@ -74,6 +74,51 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <args>
+                        <arg>-Xjsr305=strict</arg>
+                    </args>
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                    </compilerPlugins>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/mongo-axon-example/pom.xml
+++ b/mongo-axon-example/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.mongo</groupId>
+        <artifactId>axon-mongo-parent</artifactId>
+        <version>4.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mongo-axon-example</artifactId>
+    <version>4.5-SNAPSHOT</version>
+
+    <name>Axon Framework Mongo Extension - Spring Boot Example</name>
+    <description>Example module for the Mongo Extension of Axon Framework</description>
+
+    <properties>
+        <kotlin.version>1.4.31</kotlin.version>
+        <kotlin-logging-jvm.version>2.0.6</kotlin-logging-jvm.version>
+        <spring.boot.version>2.4.3</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>${axon.version}</version>
+            <!-- Excluding as we are not going to use Axon Server as out Event Store -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-server-connector</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework.extensions.mongo</groupId>
+            <artifactId>axon-mongo</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging-jvm</artifactId>
+            <version>${kotlin-logging-jvm.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/MongoAxonExampleApplication.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/MongoAxonExampleApplication.kt
@@ -28,8 +28,8 @@ import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoEventSto
 import org.axonframework.extensions.mongo.eventsourcing.tokenstore.MongoTokenStore
 import org.axonframework.serialization.Serializer
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -38,7 +38,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
  * Starting point.
  */
 fun main(args: Array<String>) {
-    SpringApplication.run(MongoAxonExampleApplication::class.java, *args)
+    runApplication<MongoAxonExampleApplication>(*args)
 }
 
 /**

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/MongoAxonExampleApplication.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/MongoAxonExampleApplication.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example
+
+import com.mongodb.client.MongoClient
+import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine
+import org.axonframework.extensions.mongo.DefaultMongoTemplate
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.MongoEventStorageEngine
+import org.axonframework.extensions.mongo.eventsourcing.tokenstore.MongoTokenStore
+import org.axonframework.serialization.Serializer
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.axonframework.eventsourcing.EventCountSnapshotTriggerDefinition
+
+import org.axonframework.eventsourcing.Snapshotter
+
+import org.axonframework.eventsourcing.SnapshotTriggerDefinition
+
+
+/**
+ * Starting point.
+ */
+fun main(args: Array<String>) {
+    SpringApplication.run(MongoAxonExampleApplication::class.java, *args)
+}
+
+/**
+ * Main application class.
+ */
+@SpringBootApplication
+@EnableScheduling
+class MongoAxonExampleApplication {
+
+    /**
+     * Configures Mongo as the Storage Engine.
+     */
+    @Bean
+    fun storageEngine(client: MongoClient) = MongoEventStorageEngine.builder()
+        .mongoTemplate(
+            DefaultMongoTemplate.builder()
+                .mongoDatabase(client)
+                .build()
+        )
+        .build()
+
+    /**
+     * Configures to use Mongo embedded event store.
+     */
+    @Bean
+    fun eventStore(storageEngine: EventStorageEngine) = EmbeddedEventStore.builder().storageEngine(storageEngine).build()
+
+    /**
+     * Configures to use in-memory token store.
+     */
+    @Bean
+    fun tokenStore(client: MongoClient, serializer: Serializer) = MongoTokenStore.builder()
+        .mongoTemplate(
+            DefaultMongoTemplate.builder()
+                .mongoDatabase(client)
+                .build()
+        )
+        .serializer(serializer)
+        .build()
+
+    /**
+     * Configures a snapshot trigger to create a Snapshot every 5 events. 5 is an arbitrary number used only for testing purposes just to show how the snapshots are stored on Mongo as well.
+     */
+    @Bean
+    fun mySnapshotTriggerDefinition(snapshotter: Snapshotter): SnapshotTriggerDefinition? {
+        return EventCountSnapshotTriggerDefinition(snapshotter, 5)
+    }
+
+}

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/api/Commands.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/api/Commands.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example.api
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier
+
+/**
+ * Create account.
+ */
+data class CreateBankAccountCommand(
+    @TargetAggregateIdentifier
+    val bankAccountId: String,
+    val overdraftLimit: Long
+)
+
+/**
+ * Deposit money.
+ */
+data class DepositMoneyCommand(
+    @TargetAggregateIdentifier
+    val bankAccountId: String,
+    val amountOfMoney: Long
+)
+
+/**
+ * Withdraw money.
+ */
+data class WithdrawMoneyCommand(
+    @TargetAggregateIdentifier
+    val bankAccountId: String,
+    val amountOfMoney: Long
+)
+
+/**
+ * Return money if transfer is not possible.
+ */
+data class ReturnMoneyOfFailedBankTransferCommand(
+    @TargetAggregateIdentifier
+    val bankAccountId: String,
+    val amount: Long
+)

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/api/Events.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/api/Events.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example.api
+
+/**
+ * Account created.
+ */
+data class BankAccountCreatedEvent(
+        val id: String,
+        val overdraftLimit: Long
+)
+
+/**
+ * Collecting event for increasing amount.
+ */
+sealed class MoneyAddedEvent(
+        open val bankAccountId: String,
+        open val amount: Long
+)
+
+/**
+ * Money deposited.
+ */
+data class MoneyDepositedEvent(override val bankAccountId: String, override val amount: Long) : MoneyAddedEvent(bankAccountId, amount)
+
+/**
+ * Money returned.
+ */
+data class MoneyOfFailedBankTransferReturnedEvent(override val bankAccountId: String, override val amount: Long) : MoneyAddedEvent(bankAccountId, amount)
+
+/**
+ * Money received via transfer.
+ */
+data class DestinationBankAccountCreditedEvent(override val bankAccountId: String, override val amount: Long, val bankTransferId: String) : MoneyAddedEvent(bankAccountId, amount)
+
+/**
+ * Collecting event for decreasing amount.
+ */
+sealed class MoneySubtractedEvent(
+        open val bankAccountId: String,
+        open val amount: Long
+)
+
+/**
+ * Money withdrawn.
+ */
+data class MoneyWithdrawnEvent(override val bankAccountId: String, override val amount: Long) : MoneySubtractedEvent(bankAccountId, amount)
+
+/**
+ * Money transferred.
+ */
+data class SourceBankAccountDebitedEvent(override val bankAccountId: String, override val amount: Long, val bankTransferId: String) : MoneySubtractedEvent(bankAccountId, amount)
+
+/**
+ * Money transfer rejected.
+ */
+data class SourceBankAccountDebitRejectedEvent(val bankTransferId: String)

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/api/Queries.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/api/Queries.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example.api
+
+data class AccountBalanceQuery(val bankAccountId: String)

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/client/BankClient.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/client/BankClient.kt
@@ -47,7 +47,7 @@ class BankClient(
      */
     @Scheduled(initialDelay = 5_000, fixedDelay = 1000_000_000)
     fun createAccount() {
-        commandGateway.send<CompletableFuture<String>>(
+        commandGateway.send<String>(
             CreateBankAccountCommand(
                 bankAccountId = accountId,
                 overdraftLimit = 1000
@@ -60,7 +60,7 @@ class BankClient(
      */
     @Scheduled(initialDelay = 10_000, fixedDelay = 20_000)
     fun deposit() {
-        commandGateway.send<CompletableFuture<String>>(
+        commandGateway.send<Any?>(
             DepositMoneyCommand(
                 bankAccountId = accountId,
                 amountOfMoney = amount.toLong()

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/client/BankClient.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/client/BankClient.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example.client
+
+import mu.KLogging
+import org.axonframework.commandhandling.gateway.CommandGateway
+import org.axonframework.extension.mongo.example.api.AccountBalanceQuery
+import org.axonframework.extension.mongo.example.api.CreateBankAccountCommand
+import org.axonframework.extension.mongo.example.api.DepositMoneyCommand
+import org.axonframework.messaging.responsetypes.ResponseTypes
+import org.axonframework.queryhandling.QueryGateway
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Bank client sending scheduled commands.
+ */
+@Component
+class BankClient(
+    private val commandGateway: CommandGateway,
+    private val queryGateway: QueryGateway
+) {
+
+    companion object : KLogging()
+
+    private val accountId = UUID.randomUUID().toString()
+    private var amount = 100
+
+    /**
+     * Creates account once.
+     */
+    @Scheduled(initialDelay = 5_000, fixedDelay = 1000_000_000)
+    fun createAccount() {
+        commandGateway.send<CompletableFuture<String>>(
+            CreateBankAccountCommand(
+                bankAccountId = accountId,
+                overdraftLimit = 1000
+            )
+        )
+    }
+
+    /**
+     * Deposit some money every 20 seconds.
+     */
+    @Scheduled(initialDelay = 10_000, fixedDelay = 20_000)
+    fun deposit() {
+        commandGateway.send<CompletableFuture<String>>(
+            DepositMoneyCommand(
+                bankAccountId = accountId,
+                amountOfMoney = amount.toLong()
+            )
+        )
+        amount = amount.inc()
+    }
+
+    /**
+     * Query the balance every 15 seconds.
+     */
+    @Scheduled(initialDelay = 10_000, fixedDelay = 15_000)
+    fun balance() {
+        val amount = queryGateway.query(
+            "org.axonframework.extension.mongo.example.api.AccountBalanceQuery",
+            AccountBalanceQuery(
+                bankAccountId = accountId
+            ),
+            ResponseTypes.instanceOf(Long::class.java)
+        )
+        logger.info { "Current amount is: ${amount.get()}" }
+    }
+}

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/core/BankAccount.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/core/BankAccount.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example.core
+
+import org.axonframework.commandhandling.CommandHandler
+import org.axonframework.eventsourcing.EventSourcingHandler
+import org.axonframework.extension.mongo.example.api.*
+import org.axonframework.modelling.command.AggregateIdentifier
+import org.axonframework.modelling.command.AggregateLifecycle.apply
+import org.axonframework.spring.stereotype.Aggregate
+
+/**
+ * Represent account.
+ */
+@Suppress("unused")
+@Aggregate(snapshotTriggerDefinition = "mySnapshotTriggerDefinition")
+class BankAccount() {
+
+    @AggregateIdentifier
+    private lateinit var id: String
+    private var overdraftLimit: Long = 0
+    private var balanceInCents: Long = 0
+
+    /**
+     * Creates a new bank account.
+     */
+    @CommandHandler
+    constructor(command: CreateBankAccountCommand) : this() {
+        apply(BankAccountCreatedEvent(command.bankAccountId, command.overdraftLimit))
+    }
+
+    /**
+     * Deposits money to account.
+     */
+    @CommandHandler
+    fun deposit(command: DepositMoneyCommand) {
+        apply(MoneyDepositedEvent(id, command.amountOfMoney))
+    }
+
+    /**
+     * Withdraw money from account.
+     */
+    @CommandHandler
+    fun withdraw(command: WithdrawMoneyCommand) {
+        if (command.amountOfMoney <= balanceInCents + overdraftLimit) {
+            apply(MoneyWithdrawnEvent(id, command.amountOfMoney))
+        }
+    }
+
+    /**
+     * Return money from account.
+     */
+    @CommandHandler
+    fun returnMoney(command: ReturnMoneyOfFailedBankTransferCommand) {
+        apply(MoneyOfFailedBankTransferReturnedEvent(id, command.amount))
+    }
+
+    /**
+     * Handler to initialize bank accounts attributes.
+     */
+    @EventSourcingHandler
+    fun on(event: BankAccountCreatedEvent) {
+        id = event.id
+        overdraftLimit = event.overdraftLimit
+        balanceInCents = 0
+    }
+
+    /**
+     * Handler adjusting balance.
+     */
+    @EventSourcingHandler
+    fun on(event: MoneyAddedEvent) {
+        balanceInCents += event.amount
+    }
+
+    /**
+     * Handler adjusting balance.
+     */
+    @EventSourcingHandler
+    fun on(event: MoneySubtractedEvent) {
+        balanceInCents -= event.amount
+    }
+}

--- a/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/handler/BankEventHandler.kt
+++ b/mongo-axon-example/src/main/kotlin/org/axonframework/extension/mongo/example/handler/BankEventHandler.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.mongo.example.handler
+
+import mu.KLogging
+import org.axonframework.eventhandling.EventHandler
+import org.axonframework.eventhandling.EventMessage
+import org.axonframework.extension.mongo.example.api.AccountBalanceQuery
+import org.axonframework.extension.mongo.example.api.BankAccountCreatedEvent
+import org.axonframework.extension.mongo.example.api.MoneyAddedEvent
+import org.axonframework.queryhandling.QueryHandler
+import org.springframework.stereotype.Component
+
+@Component
+class BankEventHandler {
+
+    companion object : KLogging()
+
+    private val accountAmount = HashMap<String, Long?>()
+
+    /**
+     * Account created event.
+     */
+    @EventHandler
+    fun <T : EventMessage<Any>> on(event: BankAccountCreatedEvent) {
+        logger.info { "account created: ${event.id}" }
+        accountAmount[event.id] = 0
+    }
+
+    /**
+     * Add money to the account.
+     */
+    @EventHandler
+    fun <T : EventMessage<Any>> on(event: MoneyAddedEvent) {
+        logger.info { "money added to: ${event.bankAccountId}" }
+        // sum old amount plus new one
+        val amount = accountAmount[event.bankAccountId]?.plus(event.amount)
+        accountAmount[event.bankAccountId] = amount
+    }
+
+    /**
+     * Check account balance.
+     */
+    @QueryHandler
+    fun on(query: AccountBalanceQuery): Long? {
+        logger.info { "received query ${query.bankAccountId}" }
+        return accountAmount[query.bankAccountId]
+    }
+
+}

--- a/mongo-axon-example/src/main/resources/application.yml
+++ b/mongo-axon-example/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: mongoAxonExample

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <version>4.5-SNAPSHOT</version>
     <modules>
         <module>mongo</module>
+        <module>mongo-axon-example</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Added an Axon Mongo Example module aiming to show how to use `extension-mongo` on a simple `spring-boot` project and also to be used for testing future changes/enhancements of the extension.