### PR TITLE
[#270] Implement SequencedDeadLetterQueue for Mongo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build with Coverage reports
         if: matrix.sonar-enabled
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Dcoverage clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh,coverage clean verify
 
       - name: Build coverage report
         if: matrix.sonar-enabled

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Coverage reports
         if: matrix.sonar-enabled
         run: |
-          ./mvnw -B -U -Dstyle.color=always -Possrh -Dcoverage clean verify
+          ./mvnw -B -U -Dstyle.color=always -Possrh,coverage clean verify
 
       - name: Build coverage report
         if: matrix.sonar-enabled

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>axon-mongo-coverage-report</artifactId>
-    <version>4.6.0-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
 
     <name>Axon Framework Mongo Extension - Coverage Report Generator</name>
     <description>Coverage Report Generator for the Axon Mongo Extension</description>

--- a/mongo/pom.xml
+++ b/mongo/pom.xml
@@ -79,6 +79,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${axon.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
             <version>${spring.version}</version>

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/DefaultMongoTemplate.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/DefaultMongoTemplate.java
@@ -27,7 +27,12 @@ import java.util.Objects;
 import static org.axonframework.common.BuilderUtils.assertThat;
 
 /**
- * MongoTemplate instance giving direct access to the TrackingToken collection via a given MongoClient instance.
+ * MongoTemplate instance giving direct access to several collection via a given MongoClient instance. Will use the
+ * default nane for the collection, when none is set for the specific collections.
+ * </p>
+ * The defaults are {@code domainevents} for the domain events, {@code snapshotevents} for the snapshots events,
+ * {@code trackingtokens} for the tracking tokens, {@code sagas} for the sagas and {@code deadletters} for the dead
+ * letter.
  *
  * @author Allard Buijze
  * @since 3.0
@@ -38,12 +43,13 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
     private final String snapshotEventsCollectionName;
     private final String trackingTokensCollectionName;
     private final String sagasCollectionName;
+    private final String deadLetterCollectionName;
 
     /**
      * Instantiate a {@link DefaultMongoTemplate} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link MongoDatabase} is not {@code null}, and will throw an {@link
-     * AxonConfigurationException} if any of them is {@code null}.
+     * Will assert that the {@link MongoDatabase} is not {@code null}, and will throw an
+     * {@link AxonConfigurationException} if any of them is {@code null}.
      *
      * @param builder the {@link Builder} used to instantiate a {@link DefaultMongoTemplate} instance
      */
@@ -53,14 +59,15 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
         this.snapshotEventsCollectionName = builder.snapshotEventsCollectionName;
         this.sagasCollectionName = builder.sagasCollectionName;
         this.trackingTokensCollectionName = builder.trackingTokensCollectionName;
+        this.deadLetterCollectionName = builder.deadLetterCollectionName;
     }
 
     /**
      * Instantiate a Builder to be able to create a {@link DefaultMongoTemplate}.
      * <p>
-     * The {@code domainEventsCollectionName}, {@code snapshotEventsCollectionName}, {@code
-     * trackingTokensCollectionName} and (@code sagasCollectionName} are respectively defaulted to {@code
-     * trackingtokens}, {@code domainevents}, {@code snapshotevents} and {@code sagas}.
+     * The {@code domainEventsCollectionName}, {@code snapshotEventsCollectionName},
+     * {@code trackingTokensCollectionName} and (@code sagasCollectionName} are respectively defaulted to
+     * {@code trackingtokens}, {@code domainevents}, {@code snapshotevents} and {@code sagas}.
      * <p>
      * The {@link MongoDatabase} is a <b>hard requirement</b> and as such should be provided. Can either be provided
      * directly, or by setting a {@link MongoClient}. When choosing the latter approach, the MongoDatabase name can be
@@ -73,42 +80,87 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
         return new Builder();
     }
 
+    /**
+     * Overwrites the {@code snapshotEventsCollectionName} to use as the collection name for Snapshot Events.
+     *
+     * @param snapshotEventsCollectionName a {@link String} specifying the collection name for Snapshot Events
+     * @return a new {@link DefaultMongoTemplate} with the given {@code snapshotEventsCollectionName} set.
+     */
     public DefaultMongoTemplate withSnapshotCollection(String snapshotEventsCollectionName) {
         return DefaultMongoTemplate.builder()
                                    .mongoDatabase(database())
                                    .domainEventsCollectionName(domainEventsCollectionName)
                                    .snapshotEventsCollectionName(snapshotEventsCollectionName)
                                    .sagasCollectionName(sagasCollectionName)
+                                   .deadLetterCollectionName(deadLetterCollectionName)
                                    .trackingTokensCollectionName(trackingTokensCollectionName)
                                    .build();
     }
 
+    /**
+     * Overwrites the {@code domainEventsCollectionName} to use as the collection name for Domain Events.
+     *
+     * @param domainEventsCollectionName a {@link String} specifying the collection name for Domain Events
+     * @return a new {@link DefaultMongoTemplate} with the given {@code domainEventsCollectionName} set.
+     */
     public DefaultMongoTemplate withDomainEventsCollection(String domainEventsCollectionName) {
         return DefaultMongoTemplate.builder()
                                    .mongoDatabase(database())
                                    .domainEventsCollectionName(domainEventsCollectionName)
                                    .snapshotEventsCollectionName(snapshotEventsCollectionName)
                                    .sagasCollectionName(sagasCollectionName)
+                                   .deadLetterCollectionName(deadLetterCollectionName)
                                    .trackingTokensCollectionName(trackingTokensCollectionName)
                                    .build();
     }
 
+    /**
+     * Overwrites the {@code sagasCollectionName} to use as the collection name for Sagas.
+     *
+     * @param sagasCollectionName a {@link String} specifying the collection name for Sagas
+     * @return a new {@link DefaultMongoTemplate} with the given {@code sagasCollectionName} set.
+     */
     public DefaultMongoTemplate withSagasCollection(String sagasCollectionName) {
         return DefaultMongoTemplate.builder()
                                    .mongoDatabase(database())
                                    .domainEventsCollectionName(domainEventsCollectionName)
                                    .snapshotEventsCollectionName(snapshotEventsCollectionName)
                                    .sagasCollectionName(sagasCollectionName)
+                                   .deadLetterCollectionName(deadLetterCollectionName)
                                    .trackingTokensCollectionName(trackingTokensCollectionName)
                                    .build();
     }
 
+    /**
+     * Overwrites the {@code deadLetterCollectionName} to use as the collection name for dead letters.
+     *
+     * @param deadLetterCollectionName a {@link String} specifying the collection name for dead letters
+     * @return a new {@link DefaultMongoTemplate} with the given {@code deadLetterCollectionName} set.
+     */
+    public DefaultMongoTemplate withDeadLetterCollection(String deadLetterCollectionName) {
+        return DefaultMongoTemplate.builder()
+                                   .mongoDatabase(database())
+                                   .domainEventsCollectionName(domainEventsCollectionName)
+                                   .snapshotEventsCollectionName(snapshotEventsCollectionName)
+                                   .sagasCollectionName(sagasCollectionName)
+                                   .deadLetterCollectionName(deadLetterCollectionName)
+                                   .trackingTokensCollectionName(trackingTokensCollectionName)
+                                   .build();
+    }
+
+    /**
+     * Overwrites the {@code trackingTokensCollectionName} to use as the collection name for tracking tokens.
+     *
+     * @param trackingTokensCollectionName a {@link String} specifying the collection name for tracking tokens
+     * @return a new {@link DefaultMongoTemplate} with the given {@code trackingTokensCollectionName} set.
+     */
     public DefaultMongoTemplate withTrackingTokenCollection(String trackingTokensCollectionName) {
         return DefaultMongoTemplate.builder()
                                    .mongoDatabase(database())
                                    .domainEventsCollectionName(domainEventsCollectionName)
                                    .snapshotEventsCollectionName(snapshotEventsCollectionName)
                                    .sagasCollectionName(sagasCollectionName)
+                                   .deadLetterCollectionName(deadLetterCollectionName)
                                    .trackingTokensCollectionName(trackingTokensCollectionName)
                                    .build();
     }
@@ -133,12 +185,18 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
         return database().getCollection(sagasCollectionName);
     }
 
+    @Override
+    public MongoCollection<Document> deadLetterCollection() {
+        return database().getCollection(deadLetterCollectionName);
+    }
+
     /**
      * Builder class to instantiate a {@link DefaultMongoTemplate}.
      * <p>
-     * The {@code domainEventsCollectionName}, {@code snapshotEventsCollectionName}, {@code
-     * trackingTokensCollectionName} and (@code sagasCollectionName} are respectively defaulted to {@code
-     * trackingtokens}, {@code domainevents}, {@code snapshotevents} and {@code sagas}.
+     * The {@code domainEventsCollectionName}, {@code snapshotEventsCollectionName},
+     * {@code trackingTokensCollectionName}, {@code sagasCollectionName} and (@code deadLetterCollectionName} are
+     * respectively defaulted to {@code trackingtokens}, {@code domainevents}, {@code snapshotevents}, {@code sagas} and
+     * {@code deadletters}.
      * <p>
      * The {@link MongoDatabase} is a <b>hard requirement</b> and as such should be provided. Can either be provided
      * directly, or by setting a {@link MongoClient}. When choosing the latter approach, the MongoDatabase name can be
@@ -151,6 +209,7 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
         private String snapshotEventsCollectionName = "snapshotevents";
         private String trackingTokensCollectionName = "trackingtokens";
         private String sagasCollectionName = "sagas";
+        private String deadLetterCollectionName = "deadletters";
 
         @Override
         public Builder mongoDatabase(MongoClient mongoClient) {
@@ -210,8 +269,8 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
         }
 
         /**
-         * Sets the {@code sagasCollectionName} to use as the collection name for Saga instances. Defaults to a {@code
-         * "sagas"} {@link String}.
+         * Sets the {@code sagasCollectionName} to use as the collection name for Saga instances. Defaults to a
+         * {@code "sagas"} {@link String}.
          *
          * @param sagasCollectionName a {@link String} specifying the collection name for Sagas
          * @return the current Builder instance, for fluent interfacing
@@ -219,6 +278,19 @@ public class DefaultMongoTemplate extends AbstractMongoTemplate implements Mongo
         public Builder sagasCollectionName(String sagasCollectionName) {
             assertName(sagasCollectionName, "sagasCollectionName");
             this.sagasCollectionName = sagasCollectionName;
+            return this;
+        }
+
+        /**
+         * Sets the {@code deadLetterCollectionName} to use as the collection name for Dead letters. Defaults to a
+         * {@code "deadletters"} {@link String}.
+         *
+         * @param deadLetterCollectionName a {@link String} specifying the collection name for Dead letters
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder deadLetterCollectionName(String deadLetterCollectionName) {
+            assertName(deadLetterCollectionName, "deadLetterCollectionName");
+            this.deadLetterCollectionName = deadLetterCollectionName;
             return this;
         }
 

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/MongoTemplate.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/MongoTemplate.java
@@ -52,4 +52,11 @@ public interface MongoTemplate {
      */
     MongoCollection<Document> sagaCollection();
 
+    /**
+     * Returns a reference to the collection containing the dead letter instances.
+     *
+     * @return MongoCollection containing the dead letters
+     */
+    MongoCollection<Document> deadLetterCollection();
+
 }

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEntry.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEntry.java
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.client.DistinctIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Accumulators;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Projections;
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent.EventEntryConfiguration;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.deadletter.Cause;
+import org.axonframework.serialization.SerializedMetaData;
+import org.axonframework.serialization.Serializer;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Sorts.ascending;
+import static com.mongodb.client.model.Sorts.descending;
+import static com.mongodb.client.model.Updates.set;
+import static org.axonframework.extensions.mongo.eventhandling.deadletter.InstantEntry.NANOSECONDS_KEY;
+import static org.axonframework.extensions.mongo.eventhandling.deadletter.InstantEntry.SECONDS_KEY;
+
+/**
+ * Default DeadLetter Mongo entity implementation of dead letters. Used by the {@link MongoSequencedDeadLetterQueue} to
+ * store these into the database to be retried later.
+ * <p>
+ * The original message is embedded as a {@link DeadLetterEventEntry}. This is mapped, upon both storage and retrieval,
+ * by one of the configured {@link DeadLetterMongoConverter converters}.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class DeadLetterEntry {
+
+    private static final int ORDER_ASC = 1;
+
+    private static final String PROCESSING_GROUP_KEY = "processingGroup";
+    private static final String SEQUENCE_IDENTIFIER_KEY = "sequenceIdentifier";
+    private static final String INDEX_KEY = "index";
+    private static final String MESSAGE_KEY = "message";
+    private static final String ENQUEUED_AT_KEY = "enqueuedAt";
+    private static final String LAST_TOUCHED_KEY = "lastTouched";
+    private static final String LAST_TOUCHED_SECONDS_KEY = LAST_TOUCHED_KEY + "." + SECONDS_KEY;
+    private static final String LAST_TOUCHED_NANOSECONDS_KEY = LAST_TOUCHED_KEY + "." + NANOSECONDS_KEY;
+    private static final String PROCESSING_STARTED_KEY = "processingStarted";
+    private static final String PROCESSING_STARTED_SECONDS_KEY = PROCESSING_STARTED_KEY + "." + SECONDS_KEY;
+    private static final String PROCESSING_STARTED_NANOSECONDS_KEY = PROCESSING_STARTED_KEY + "." + NANOSECONDS_KEY;
+    private static final String CAUSE_TYPE_KEY = "causeType";
+    private static final String CAUSE_MESSAGE_KEY = "causeMessage";
+    private static final String DIAGNOSTICS_KEY = "diagnostics";
+
+    private final String processingGroup;
+    private final String sequenceIdentifier;
+    private final long index;
+    private final Document message;
+    private final Document enqueuedAt;
+    private Document lastTouched;
+    private Document processingStarted;
+    private String causeType;
+    private String causeMessage;
+    private Object serializedDiagnostics;
+
+    /**
+     * Initializes a {@link DeadLetterEntry} entry using a DBObject containing the Mongo Document.
+     *
+     * @param dbDeadLetterEntry The mongo Document containing the serialized dead letter.
+     */
+    public DeadLetterEntry(Document dbDeadLetterEntry) {
+        this.processingGroup = dbDeadLetterEntry.getString(PROCESSING_GROUP_KEY);
+        this.sequenceIdentifier = dbDeadLetterEntry.getString(SEQUENCE_IDENTIFIER_KEY);
+        this.index = dbDeadLetterEntry.getLong(INDEX_KEY);
+        this.message = (Document) dbDeadLetterEntry.get(MESSAGE_KEY);
+        this.enqueuedAt = (Document) dbDeadLetterEntry.get(ENQUEUED_AT_KEY);
+        this.lastTouched = (Document) dbDeadLetterEntry.get(LAST_TOUCHED_KEY);
+        this.processingStarted = (Document) dbDeadLetterEntry.get(PROCESSING_STARTED_KEY);
+        this.causeType = dbDeadLetterEntry.getString(CAUSE_TYPE_KEY);
+        this.causeMessage = dbDeadLetterEntry.getString(CAUSE_MESSAGE_KEY);
+        this.serializedDiagnostics = dbDeadLetterEntry.get(DIAGNOSTICS_KEY);
+    }
+
+    /**
+     * Creates a new {@link DeadLetterEntry} consisting of the given parameters.
+     *
+     * @param processingGroup    The processing group this message belongs to.
+     * @param sequenceIdentifier The sequence identifier this message belongs to.
+     * @param index              The index of this message within the sequence.
+     * @param message            The message stored as {@link Document}.
+     * @param enqueuedAt         The time the message was enqueued.
+     * @param lastTouched        The time the message has been last processed.
+     * @param cause              The reason the message was enqueued.
+     * @param diagnostics        The diagnostics, a map of metadata.
+     * @param serializer         Serializer to use for the diagnostics
+     */
+    @SuppressWarnings("squid:S107")
+    public DeadLetterEntry(String processingGroup,
+                           String sequenceIdentifier,
+                           long index,
+                           Document message,
+                           Instant enqueuedAt,
+                           Instant lastTouched,
+                           Cause cause,
+                           MetaData diagnostics,
+                           Serializer serializer) {
+        this.processingGroup = processingGroup;
+        this.sequenceIdentifier = sequenceIdentifier;
+        this.index = index;
+        this.message = message;
+        this.enqueuedAt = new InstantEntry(enqueuedAt).asDocument();
+        this.lastTouched = new InstantEntry(lastTouched).asDocument();
+        Optional.ofNullable(cause).ifPresent(c -> {
+            this.causeType = c.type();
+            this.causeMessage = c.message();
+        });
+        Class<?> serializationTarget = String.class;
+        if (serializer.canSerializeTo(DBObject.class)) {
+            serializationTarget = DBObject.class;
+        }
+        this.serializedDiagnostics = serializer.serialize(diagnostics, serializationTarget).getData();
+    }
+
+    /**
+     * Returns the current dead letter as a mongo Document.
+     *
+     * @return Document representing the entry.
+     */
+    public Document asDocument() {
+        return new Document()
+                .append(PROCESSING_GROUP_KEY, processingGroup)
+                .append(SEQUENCE_IDENTIFIER_KEY, sequenceIdentifier)
+                .append(INDEX_KEY, index)
+                .append(MESSAGE_KEY, message)
+                .append(ENQUEUED_AT_KEY, enqueuedAt)
+                .append(LAST_TOUCHED_KEY, lastTouched)
+                .append(PROCESSING_STARTED_KEY, processingStarted)
+                .append(CAUSE_TYPE_KEY, causeType)
+                .append(CAUSE_MESSAGE_KEY, causeMessage)
+                .append(DIAGNOSTICS_KEY, serializedDiagnostics);
+    }
+
+    /**
+     * The processing group this dead letter belongs to.
+     *
+     * @return The processing group.
+     */
+    public String getProcessingGroup() {
+        return processingGroup;
+    }
+
+    /**
+     * The sequence identifier of this dead letter. If two have the same, they must be handled sequentially.
+     *
+     * @return The sequence identifier.
+     */
+    public String getSequenceIdentifier() {
+        return sequenceIdentifier;
+    }
+
+    /**
+     * The index of this message within the {@link #getSequenceIdentifier()}, used for keeping the messages in the same
+     * order within the same sequence.
+     *
+     * @return The index.
+     */
+    public long getIndex() {
+        return index;
+    }
+
+    /**
+     * The embedded {@link DeadLetterEventEntry} representing the original message.
+     *
+     * @return The embedded original message.
+     */
+    public DeadLetterEventEntry getMessage(@Nonnull EventEntryConfiguration configuration) {
+        return new DeadLetterEventEntry(message, configuration);
+    }
+
+    /**
+     * The time the message was enqueued.
+     *
+     * @return The time the message was enqueued.
+     */
+    public Instant getEnqueuedAt() {
+        return new InstantEntry(enqueuedAt).getInstant();
+    }
+
+    /**
+     * The time the messages was last touched, meaning having been queued or having been tried to process.
+     *
+     * @return The time the messages was last touched.
+     */
+    public Instant getLastTouched() {
+        return new InstantEntry(lastTouched).getInstant();
+    }
+
+    /**
+     * Sets the time the message was last touched. Should be updated every time the message has been attempted to
+     * process.
+     *
+     * @param lastTouched The new time to set to.
+     */
+    public void setLastTouched(@Nonnull Instant lastTouched) {
+        this.lastTouched = new InstantEntry(lastTouched).asDocument();
+    }
+
+    /**
+     * Timestamp indicating when the processing of this dead letter has started. Used for claiming messages and
+     * preventing multiple processes or thread from handling items concurrently within the same sequence.
+     *
+     * @return Timestamp of start processing.
+     */
+    public Instant getProcessingStarted() {
+        return Optional.ofNullable(processingStarted)
+                       .map(InstantEntry::new)
+                       .map(InstantEntry::getInstant)
+                       .orElse(null);
+    }
+
+
+    /**
+     * Sets the cause of the error when the message was originally processed, or processed later and the cause was
+     * updated.
+     *
+     * @param cause The new cause to set to.
+     */
+    public void setCause(@Nonnull Cause cause) {
+        this.causeType = cause.type();
+        this.causeMessage = cause.message();
+    }
+
+    /**
+     * Gets the class of the original exception.
+     *
+     * @return The type of the cause.
+     */
+    public String getCauseType() {
+        return causeType;
+    }
+
+    /**
+     * Gets the message of the original exception.
+     *
+     * @return The message of the cause.
+     */
+    public String getCauseMessage() {
+        return causeMessage;
+    }
+
+    /**
+     * Returns the serialized diagnostics.
+     *
+     * @return The serialized diagnostics.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes", "squid:S1452"})
+    public SerializedMetaData<?> getDiagnostics() {
+        return new SerializedMetaData(serializedDiagnostics, getRepresentationType());
+    }
+
+    /**
+     * Sets the diagnostics.
+     *
+     * @param diagnostics The new diagnostics.
+     */
+    public void setDiagnostics(@Nonnull MetaData diagnostics, @Nonnull Serializer serializer) {
+        Class<?> serializationTarget = String.class;
+        if (serializer.canSerializeTo(DBObject.class)) {
+            serializationTarget = DBObject.class;
+        }
+        this.serializedDiagnostics = serializer.serialize(diagnostics, serializationTarget).getData();
+    }
+
+    /**
+     * Releases the message for processing by another thread or process.
+     */
+    public void clearProcessingStarted() {
+        this.processingStarted = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DeadLetterEntry that = (DeadLetterEntry) o;
+
+        return Objects.equals(processingGroup, that.processingGroup) &&
+                Objects.equals(sequenceIdentifier, that.sequenceIdentifier) &&
+                Objects.equals(index, that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(processingGroup, sequenceIdentifier, index);
+    }
+
+    @Override
+    public String toString() {
+        return "DeadLetterEntry{" +
+                "processingGroup='" + processingGroup + '\'' +
+                ", sequenceIdentifier='" + sequenceIdentifier + '\'' +
+                ", index=" + index +
+                ", message=" + message +
+                ", enqueuedAt=" + enqueuedAt +
+                ", lastTouched=" + lastTouched +
+                ", processingStarted=" + processingStarted +
+                ", causeType='" + causeType + '\'' +
+                ", causeMessage='" + causeMessage + '\'' +
+                ", diagnostics=" + serializedDiagnostics +
+                '}';
+    }
+
+    /**
+     * Sets some indexes needed for the dead letter collection.
+     *
+     * @param deadLetterCollection the {@link MongoCollection} to create the indexes on.
+     */
+    public static void ensureDeadLetterIndexes(@Nonnull MongoCollection<Document> deadLetterCollection) {
+        deadLetterCollection.createIndex(
+                new BasicDBObject(PROCESSING_GROUP_KEY, ORDER_ASC),
+                new IndexOptions().unique(false).name("processingGroupIdentifierIndex"));
+        deadLetterCollection.createIndex(
+                new BasicDBObject(PROCESSING_GROUP_KEY, ORDER_ASC)
+                        .append(SEQUENCE_IDENTIFIER_KEY, ORDER_ASC),
+                new IndexOptions().unique(false).name("processingGroupAndSequenceIdentifierIndex"));
+        deadLetterCollection.createIndex(
+                new BasicDBObject(PROCESSING_GROUP_KEY, ORDER_ASC)
+                        .append(SEQUENCE_IDENTIFIER_KEY, ORDER_ASC)
+                        .append(INDEX_KEY, ORDER_ASC),
+                new IndexOptions().unique(true).name("uniqueDeadLetterEntryIndex"));
+    }
+
+    /**
+     * Filter only on processingGroup
+     *
+     * @param processingGroup the processing group
+     * @return a {@link Bson} filter.
+     */
+    public static Bson processingGroupFilter(@Nonnull String processingGroup) {
+        return eq(PROCESSING_GROUP_KEY, processingGroup);
+    }
+
+    /**
+     * Filter on processingGroup and sequenceIdentifier.
+     *
+     * @param processingGroup    the processing group.
+     * @param sequenceIdentifier the sequence identifier.
+     * @return a {@link Bson} filter.
+     */
+    public static Bson processingGroupAndSequenceIdentifierFilter(
+            @Nonnull String processingGroup,
+            @Nonnull String sequenceIdentifier
+    ) {
+        return and(eq(PROCESSING_GROUP_KEY, processingGroup),
+                   eq(SEQUENCE_IDENTIFIER_KEY, sequenceIdentifier));
+    }
+
+    /**
+     * Filter on processingGroup, sequenceIdentifier and index.
+     *
+     * @param processingGroup    the processing group.
+     * @param sequenceIdentifier the sequence identifier.
+     * @param index              the index.
+     * @return a {@link Bson} filter.
+     */
+    public static Bson findOneFilter(
+            @Nonnull String processingGroup,
+            @Nonnull String sequenceIdentifier,
+            long index
+    ) {
+        return and(eq(PROCESSING_GROUP_KEY, processingGroup),
+                   eq(SEQUENCE_IDENTIFIER_KEY, sequenceIdentifier),
+                   eq(INDEX_KEY, index));
+    }
+
+    /**
+     * Filter on processingGroup, sequenceIdentifier where the index needs to be higher than the provided
+     * {@code index}.
+     *
+     * @param processingGroup    the processing group.
+     * @param sequenceIdentifier the sequence identifier.
+     * @param index              the index.
+     * @return a {@link Bson} filter.
+     */
+    public static Bson nextItemInSequenceFilter(
+            @Nonnull String processingGroup,
+            @Nonnull String sequenceIdentifier,
+            long index
+    ) {
+        return and(eq(PROCESSING_GROUP_KEY, processingGroup),
+                   eq(SEQUENCE_IDENTIFIER_KEY, sequenceIdentifier),
+                   gt(INDEX_KEY, index));
+    }
+
+    /**
+     * Filter on processingGroup, sequenceIdentifier, index and processingStarted. The processingGroup,
+     * sequenceIdentifier and index should match. The processingStarted is either absent or earlier in time than the
+     * given {@code processingStartedLimit}.
+     *
+     * @param processingGroup        the processing group.
+     * @param sequenceIdentifier     the sequence identifier.
+     * @param index                  the index.
+     * @param processingStartedLimit the processing started limit.
+     * @return a {@link Bson} filter.
+     */
+    public static Bson uniqueNotLockedFilter(
+            @Nonnull String processingGroup,
+            @Nonnull String sequenceIdentifier,
+            long index,
+            @Nonnull Instant processingStartedLimit
+    ) {
+        return and(eq(PROCESSING_GROUP_KEY, processingGroup),
+                   eq(SEQUENCE_IDENTIFIER_KEY, sequenceIdentifier),
+                   eq(INDEX_KEY, index),
+                   or(exists(PROCESSING_STARTED_SECONDS_KEY, false),
+                      lt(PROCESSING_STARTED_SECONDS_KEY, processingStartedLimit.getEpochSecond()),
+                      and(
+                              eq(PROCESSING_STARTED_SECONDS_KEY, processingStartedLimit.getEpochSecond()),
+                              lt(PROCESSING_STARTED_NANOSECONDS_KEY, processingStartedLimit.getNano())
+                      )));
+    }
+
+    /**
+     * Provides a pipeline which can be used in an aggregate to get the id's of dead letters where, only the processing
+     * group is included, for each queue only the first, with the lowest index is considered, it should be claimable,
+     * and the result is sorted by last touched. The pipeline can be used in a {@link MongoCollection#aggregate(List)}.
+     *
+     * @param processingGroup        the processing group.
+     * @param processingStartedLimit the processing started limit.
+     * @return a {@link Bson} pipeline – the aggregation pipeline.
+     */
+    @SuppressWarnings("squid:S1452")
+    public static List<? extends Bson> firstNotLockedFilter(
+            @Nonnull String processingGroup,
+            @Nonnull Instant processingStartedLimit
+    ) {
+        Document result = new Document()
+                .append(LAST_TOUCHED_KEY, "$" + LAST_TOUCHED_KEY)
+                .append(PROCESSING_STARTED_KEY, "$" + PROCESSING_STARTED_KEY)
+                .append("_id", "$_id");
+
+        return Arrays.asList(
+                Aggregates.match(eq(PROCESSING_GROUP_KEY, processingGroup)),
+                Aggregates.group("$" + SEQUENCE_IDENTIFIER_KEY,
+                                 Accumulators.first(INDEX_KEY, result)),
+                Aggregates.replaceRoot("$" + INDEX_KEY),
+                Aggregates.match(or(exists(PROCESSING_STARTED_SECONDS_KEY, false),
+                                    lt(PROCESSING_STARTED_SECONDS_KEY,
+                                       processingStartedLimit.getEpochSecond()),
+                                    and(eq(PROCESSING_STARTED_SECONDS_KEY,
+                                           processingStartedLimit.getEpochSecond()),
+                                        lt(PROCESSING_STARTED_NANOSECONDS_KEY,
+                                           processingStartedLimit.getNano())
+                                    ))),
+                Aggregates.sort(ascending(LAST_TOUCHED_SECONDS_KEY, LAST_TOUCHED_NANOSECONDS_KEY)),
+                Aggregates.project(Projections.fields(Projections.include("_id")))
+        );
+    }
+
+    /**
+     * {@link Bson} update the processing started value to the given {@code now} value.
+     *
+     * @param now the current time as instant
+     * @return a {@link Bson} filter
+     */
+    public static Bson updateProcessingStarted(
+            @Nonnull Instant now
+    ) {
+        return set(PROCESSING_STARTED_KEY, new InstantEntry(now).asDocument());
+    }
+
+    /**
+     * Get an iterator for all the sequence identifiers of a certain processing group. These are no guarantees on the
+     * ordering.
+     *
+     * @param collection      the {@link MongoCollection} to distinct on.
+     * @param processingGroup the processing group.
+     * @return a {@link DistinctIterable} with sequence identifiers.
+     */
+    public static DistinctIterable<String> sequenceIdentifierIterator(
+            @Nonnull MongoCollection<Document> collection,
+            @Nonnull String processingGroup
+    ) {
+        return collection.distinct(
+                SEQUENCE_IDENTIFIER_KEY,
+                processingGroupFilter(processingGroup),
+                String.class
+        );
+    }
+
+    /**
+     * Sorts by index descending, so the highest first.
+     *
+     * @return a {@link Bson} sort.
+     */
+    public static Bson indexSortDescending() {
+        return descending(INDEX_KEY);
+    }
+
+    /**
+     * Sorts by index ascending, so the lowest first.
+     *
+     * @return a {@link Bson} sort.
+     */
+    public static Bson indexSortAscending() {
+        return ascending(INDEX_KEY);
+    }
+
+    /**
+     * Returns the index if present on the document, returns {@code null} when not present or document is null.
+     *
+     * @param document a {@link Document} which is expected to be a {@link DeadLetterEntry} representation.
+     * @return the index retrieved, or null.
+     */
+    public static Long index(@Nullable Document document) {
+        return Optional.ofNullable(document)
+                       .map(d -> d.getLong(INDEX_KEY))
+                       .orElse(null);
+    }
+
+    /**
+     * Returns whether this dead letter is locked, as check before trying to claim it.
+     *
+     * @param processingStartedLimit the processing started limit.
+     * @param dbDeadLetterEntry      the {@link DeadLetterEntry} as raw mongo {@link Document}.
+     * @return if the document is currently locked.
+     */
+    public static boolean isLocked(@Nonnull Instant processingStartedLimit, @Nonnull Document dbDeadLetterEntry) {
+        return Optional.ofNullable((Document) dbDeadLetterEntry.get(PROCESSING_STARTED_KEY))
+                       .map(InstantEntry::new)
+                       .map(InstantEntry::getInstant)
+                       .map(ps -> ps.isAfter(processingStartedLimit))
+                       .orElse(false);
+    }
+
+    private Class<?> getRepresentationType() {
+        Class<?> representationType = String.class;
+        if (serializedDiagnostics instanceof DBObject) {
+            representationType = DBObject.class;
+        } else if (serializedDiagnostics instanceof Document) {
+            representationType = Document.class;
+        }
+        return representationType;
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEventEntry.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEventEntry.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent.EventEntry;
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent.EventEntryConfiguration;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.SimpleSerializedObject;
+import org.bson.Document;
+import org.bson.types.Binary;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Represents an {@link org.axonframework.eventhandling.EventMessage} when stored into the database. It contains all
+ * properties known in the framework implementations. Based on which properties are present, the original message type
+ * can be determined. For example, if an aggregate identifier is present, it was a {@link DomainEventMessage}.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class DeadLetterEventEntry extends EventEntry {
+
+    private static final String MESSAGE_TYPE_KEY = "messageType";
+    private static final String TOKEN_TYPE_KEY = "tokenType";
+    private static final String TOKEN_KEY = "token";
+
+    private String messageType;
+    private String tokenType;
+    private byte[] token;
+
+    /**
+     * Create a new {@code DeadLetterEventEntry} based on data provided by Mongo.
+     *
+     * @param dbObject      Mongo object that contains data to represent a {@code DeadLetterEventEntry}.
+     * @param configuration Configuration containing the property names.
+     */
+    public DeadLetterEventEntry(@Nonnull Document dbObject, @Nonnull EventEntryConfiguration configuration) {
+        super(dbObject, configuration);
+        this.messageType = dbObject.getString(MESSAGE_TYPE_KEY);
+        Optional.ofNullable(dbObject.getString(TOKEN_TYPE_KEY)).ifPresent(type -> this.tokenType = type);
+        Optional.ofNullable(dbObject.get(TOKEN_KEY)).ifPresent(t -> this.token = ((Binary) t).getData());
+    }
+
+    /**
+     * Constructor used to create a new dead letter event entry to store in Mongo. Should not be used directly, use
+     * {@link #fromEventMessage(EventMessage, Serializer)} instead.
+     *
+     * @param event      The actual Event to store.
+     * @param serializer Serializer to use for the event to store.
+     */
+    private DeadLetterEventEntry(@Nonnull DomainEventMessage<?> event, @Nonnull Serializer serializer) {
+        super(event, serializer);
+    }
+
+    /**
+     * Static method to create a new dead letter event entry to store in Mongo from any event.
+     *
+     * @param message    The actual message to store.
+     * @param serializer Serializer to use for the event to store and optionally for the tracking token.
+     * @return a new {@link DeadLetterEventEntry} instance.
+     */
+    @SuppressWarnings("squid:S1874")
+    public static DeadLetterEventEntry fromEventMessage(
+            @Nonnull EventMessage<?> message,
+            @Nonnull Serializer serializer
+    ) {
+        DeadLetterEventEntry entry = new DeadLetterEventEntry(asDomainEventMessage(message), serializer);
+        entry.messageType = message.getClass().getName();
+        Optional.of(message)
+                .filter(TrackedEventMessage.class::isInstance)
+                .map(TrackedEventMessage.class::cast)
+                .map(m -> serializer.serialize(m.trackingToken(), byte[].class))
+                .ifPresent(t -> {
+                    entry.tokenType = t.getType().getName();
+                    entry.token = t.getData();
+                });
+        return entry;
+    }
+
+    private static <T> DomainEventMessage<T> asDomainEventMessage(EventMessage<T> eventMessage) {
+        if (eventMessage instanceof DomainEventMessage<?>) {
+            return (DomainEventMessage<T>) eventMessage;
+        }
+        return new GenericDomainEventMessage<>(null, null, 0L, eventMessage,
+                                               eventMessage::getTimestamp);
+    }
+
+    /**
+     * Returns the event represented by this entry as a Mongo Document.
+     *
+     * @return Document representing the entry
+     */
+    @Override
+    public Document asDocument(@Nonnull EventEntryConfiguration configuration) {
+        Document document = super.asDocument(configuration);
+        document.append(MESSAGE_TYPE_KEY, messageType);
+        if (!isNull(tokenType) && !isNull(token)) {
+            document.append(TOKEN_TYPE_KEY, tokenType).append(TOKEN_KEY, token);
+        }
+        return document;
+    }
+
+    /**
+     * Returns the message type, which is defined by the {@link DeadLetterMongoConverter} that mapped this entry. Used
+     * for later matching whether a converter can convert it back to an
+     * {@link org.axonframework.eventhandling.EventMessage}.
+     *
+     * @return The message type.
+     */
+    public String getMessageType() {
+        return messageType;
+    }
+
+    /**
+     * Returns the original {@link TrackedEventMessage#trackingToken()} as a
+     * {@link org.axonframework.serialization.SerializedObject}, if the original message was a
+     * {@code TrackedEventMessage}.
+     *
+     * @return The original tracking token.
+     */
+    public SimpleSerializedObject<byte[]> getTrackingToken() {
+        if (token == null) {
+            return null;
+        }
+        return new SimpleSerializedObject<>(
+                token,
+                byte[].class,
+                tokenType,
+                null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+        if (getClass() != o.getClass()) {
+            return false;
+        }
+        DeadLetterEventEntry that = (DeadLetterEventEntry) o;
+        if (!Objects.equals(messageType, that.messageType)) {
+            return false;
+        }
+        if (!Objects.equals(tokenType, that.tokenType)) {
+            return false;
+        }
+        return Arrays.equals(token, that.token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(),
+                            messageType,
+                            tokenType,
+                            Arrays.hashCode(token));
+    }
+
+    @Override
+    public String toString() {
+        return "DeadLetterEventEntry{" +
+                "messageType='" + messageType + '\'' +
+                ", eventIdentifier='" + getEventIdentifier() + '\'' +
+                ", timeStamp='" + getTimestamp() + '\'' +
+                ", payload='" + getPayload() + '\'' +
+                ", metaData=" + getMetaData() +
+                ", type='" + getType() + '\'' +
+                ", aggregateIdentifier='" + getAggregateIdentifier() + '\'' +
+                ", sequenceNumber=" + getSequenceNumber() +
+                ", tokenType='" + tokenType + '\'' +
+                ", token=" + Arrays.toString(token) +
+                '}';
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterMongoConverter.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterMongoConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.serialization.Serializer;
+
+/**
+ * Converter that can convert an {@link EventMessage} to a {@link DeadLetterEventEntry} and vice versa.
+ *
+ * @param <M> The type of the event message this converter will convert.
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public interface DeadLetterMongoConverter<M extends EventMessage<?>> {
+
+    /**
+     * Converts an {@link EventMessage} implementation to a {@link DeadLetterEventEntry}.
+     *
+     * @param message    The message to convert.
+     * @param serializer The {@link Serializer} to use for serialization of payload and metadata.
+     * @return The created {@link DeadLetterEventEntry}
+     */
+    DeadLetterEventEntry convert(M message, Serializer serializer);
+
+    /**
+     * Converts a {@link DeadLetterEventEntry} to a {@link EventMessage} implementation.
+     *
+     * @param entry      The database entry to convert to a {@link EventMessage}
+     * @param serializer The {@link Serializer} to use for deserialization of payload and metadata.
+     * @return The created {@link DeadLetterEventEntry}
+     */
+    M convert(DeadLetterEventEntry entry, Serializer serializer);
+
+    /**
+     * Check whether this converter supports the given {@link DeadLetterEventEntry}.
+     *
+     * @param message The message to check support for.
+     * @return Whether the provided message is supported by this converter.
+     */
+    boolean canConvert(DeadLetterEventEntry message);
+
+    /**
+     * Check whether this converter supports the given {@link EventMessage}.
+     *
+     * @param message The message to check support for.
+     * @return Whether the provided message is supported by this converter.
+     */
+    boolean canConvert(M message);
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/EventMessageDeadLetterMongoConverter.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/EventMessageDeadLetterMongoConverter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
+import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.serialization.SerializedMessage;
+import org.axonframework.serialization.Serializer;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+
+/**
+ * Converter responsible for converting to and from known {@link EventMessage} implementations that should be supported
+ * by a {@link org.axonframework.messaging.deadletter.SequencedDeadLetterQueue} capable of storing
+ * {@code EventMessages}.
+ * <p>
+ * It rebuilds the original message implementation by checking which properties were extracted when it was originally
+ * mapped. For example, if the aggregate type and token are present, it will construct a
+ * {@link GenericTrackedDomainEventMessage}.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class EventMessageDeadLetterMongoConverter implements DeadLetterMongoConverter<EventMessage<?>> {
+
+    @Override
+    public DeadLetterEventEntry convert(EventMessage<?> message, Serializer serializer) {
+        return DeadLetterEventEntry.fromEventMessage(message, serializer);
+    }
+
+    @Override
+    public EventMessage<?> convert(DeadLetterEventEntry entry, Serializer serializer) {
+        SerializedMessage<?> serializedMessage = new SerializedMessage<>(entry.getEventIdentifier(),
+                                                                         entry.getPayload(),
+                                                                         entry.getMetaData(),
+                                                                         serializer);
+        Supplier<Instant> timestampSupplier = entry::getTimestamp;
+        if (entry.getTrackingToken() != null) {
+            TrackingToken trackingToken = serializer.deserialize(entry.getTrackingToken());
+            if (entry.getAggregateIdentifier() != null) {
+                return new GenericTrackedDomainEventMessage<>(trackingToken,
+                                                              entry.getType(),
+                                                              entry.getAggregateIdentifier(),
+                                                              entry.getSequenceNumber(),
+                                                              serializedMessage,
+                                                              timestampSupplier);
+            } else {
+                return new GenericTrackedEventMessage<>(trackingToken,
+                                                        serializedMessage,
+                                                        timestampSupplier);
+            }
+        }
+        if (entry.getAggregateIdentifier() != null) {
+            return new GenericDomainEventMessage<>(entry.getType(),
+                                                   entry.getAggregateIdentifier(),
+                                                   entry.getSequenceNumber(),
+                                                   serializedMessage.getPayload(),
+                                                   serializedMessage.getMetaData(),
+                                                   serializedMessage.getIdentifier(),
+                                                   timestampSupplier.get());
+        } else {
+            return new GenericEventMessage<>(serializedMessage,
+                                             timestampSupplier);
+        }
+    }
+
+    @Override
+    public boolean canConvert(DeadLetterEventEntry message) {
+        return message.getMessageType().equals(GenericTrackedDomainEventMessage.class.getName()) ||
+                message.getMessageType().equals(GenericEventMessage.class.getName()) ||
+                message.getMessageType().equals(GenericDomainEventMessage.class.getName()) ||
+                message.getMessageType().equals(GenericTrackedEventMessage.class.getName());
+    }
+
+    @Override
+    public boolean canConvert(EventMessage<?> message) {
+        return message instanceof GenericEventMessage;
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/InstantEntry.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/InstantEntry.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.bson.Document;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+
+/**
+ * Mongo entity for an {@link Instant} such that no precision is lost.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class InstantEntry {
+
+    static final String SECONDS_KEY = "seconds";
+    static final String NANOSECONDS_KEY = "nanoseconds";
+    static final Set<String> KEY_SET = Stream
+            .of(SECONDS_KEY, NANOSECONDS_KEY)
+            .collect(Collectors.toCollection(HashSet::new));
+
+    private final Instant instant;
+
+    /**
+     * The {@link Instant} value represented by this entry.
+     *
+     * @return the {@link Instant} value.
+     */
+    public Instant getInstant() {
+        return instant;
+    }
+
+    /**
+     * Initializes an {@link InstantEntry} entry using a DBObject containing the Mongo Document. Throws
+     * {@link NotAnInstantDocumentException} if the provided document does not have only {@code seconds} and
+     * {@code nanoseconds} as keys.
+     *
+     * @param dbInstantEntry the {@link Document} representation of the entity.
+     */
+    public InstantEntry(@Nonnull Document dbInstantEntry) {
+        Set<String> entryKeys = dbInstantEntry.keySet();
+        if (!entryKeys.equals(KEY_SET)) {
+            throw new NotAnInstantDocumentException(
+                    String.format("Actual keys on the document are %s and not %s.", entryKeys, KEY_SET)
+            );
+        }
+        long seconds = dbInstantEntry.getLong(SECONDS_KEY);
+        int nanoseconds = dbInstantEntry.getInteger(NANOSECONDS_KEY);
+        this.instant = Instant.ofEpochSecond(seconds, nanoseconds);
+    }
+
+    /**
+     * Initializes a {@link InstantEntry} entry using an {@link Instant}.
+     *
+     * @param instant the {@link Instant} representation of the entity.
+     */
+    public InstantEntry(Instant instant) {
+        this.instant = instant;
+    }
+
+    /**
+     * Returns the instant as a mongo Document.
+     *
+     * @return Document representing the instant.
+     */
+    public Document asDocument() {
+        return new Document()
+                .append(SECONDS_KEY, instant.getEpochSecond())
+                .append(NANOSECONDS_KEY, instant.getNano());
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoDeadLetter.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoDeadLetter.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.deadletter.Cause;
+import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.GenericDeadLetter;
+import org.axonframework.messaging.deadletter.ThrowableCause;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link DeadLetter} that was saved to the database and reconstructed from it. This object is immutable and should
+ * only be changed using the {@link #withCause(Throwable)}, {@link #withDiagnostics(MetaData)} and
+ * {@link #markTouched()} functions. These reconstruct a new object with the specified new properties.
+ *
+ * @param <M> The {@link EventMessage} type of the contained message.
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class MongoDeadLetter<M extends EventMessage<?>> implements DeadLetter<M> {
+
+    private final long index;
+    private final String sequenceIdentifier;
+    private final Instant enqueuedAt;
+    private final Instant lastTouched;
+    private final Cause cause;
+    private final MetaData diagnostics;
+    private final M message;
+
+    /**
+     * Constructs a new {@link MongoDeadLetter} from a {@link DeadLetterEntry}, deserialized diagnostics and a
+     * reconstructed message.
+     *
+     * @param entry       The {@link DeadLetterEntry} to construct this letter from.
+     * @param diagnostics The deserialized diagnostics {@link MetaData}.
+     * @param message     The reconstructed {@link EventMessage}.
+     */
+    public MongoDeadLetter(DeadLetterEntry entry, MetaData diagnostics, M message) {
+        this.index = entry.getIndex();
+        this.enqueuedAt = entry.getEnqueuedAt();
+        this.lastTouched = entry.getLastTouched();
+        this.sequenceIdentifier = entry.getSequenceIdentifier();
+        if (entry.getCauseType() != null) {
+            cause = new ThrowableCause(entry.getCauseType(), entry.getCauseMessage());
+        } else {
+            cause = null;
+        }
+        this.diagnostics = diagnostics;
+        this.message = message;
+    }
+
+    /**
+     * Constructs a new {@link MongoDeadLetter} with all possible parameters.
+     *
+     * @param index              The index of the {@link DeadLetterEntry}.
+     * @param sequenceIdentifier The sequenceIdentifier of the {@link DeadLetterEntry}.
+     * @param enqueuedAt         The time the message was enqueued.
+     * @param lastTouched        The time the message was last touched.
+     * @param cause              The cause of enqueueing, can be null if it was queued because there was another message
+     *                           in the same {@code sequenceIdentifier} queued.
+     * @param diagnostics        The diagnostics provided during enqueueing.
+     * @param message            The message that was enqueued.
+     */
+    @SuppressWarnings("squid:S107")
+    MongoDeadLetter(Long index,
+                    String sequenceIdentifier,
+                    Instant enqueuedAt,
+                    Instant lastTouched,
+                    Cause cause,
+                    MetaData diagnostics,
+                    M message) {
+        this.index = index;
+        this.sequenceIdentifier = sequenceIdentifier;
+        this.enqueuedAt = enqueuedAt;
+        this.lastTouched = lastTouched;
+        this.cause = cause;
+        this.diagnostics = diagnostics;
+        this.message = message;
+    }
+
+    /**
+     * The index of the dead letter within its sequence identified by the {@code sequenceIdentifier}. Will ensure the
+     * events are kept in the original order.
+     *
+     * @return The index of this {@link MongoDeadLetter}.
+     */
+    public long index() {
+        return index;
+    }
+
+    /**
+     * The sequence identifier for the {@link #message()} to be dead lettered.
+     *
+     * @return The {@link String} sequence identifier for the {@link #message()} to be dead lettered.
+     */
+    public String sequenceIdentifier() {
+        return sequenceIdentifier;
+    }
+
+    @Override
+    public M message() {
+        return message;
+    }
+
+    @Override
+    public Optional<Cause> cause() {
+        return Optional.ofNullable(cause);
+    }
+
+    @Override
+    public Instant enqueuedAt() {
+        return enqueuedAt;
+    }
+
+    @Override
+    public Instant lastTouched() {
+        return lastTouched;
+    }
+
+    @Override
+    public MetaData diagnostics() {
+        return diagnostics;
+    }
+
+    @Override
+    public DeadLetter<M> markTouched() {
+        return new MongoDeadLetter<>(index,
+                                     sequenceIdentifier,
+                                     enqueuedAt,
+                                     GenericDeadLetter.clock.instant(),
+                                     cause,
+                                     diagnostics,
+                                     message);
+    }
+
+    @Override
+    public DeadLetter<M> withCause(Throwable requeueCause) {
+        return new MongoDeadLetter<>(index,
+                                     sequenceIdentifier,
+                                     enqueuedAt,
+                                     GenericDeadLetter.clock.instant(),
+                                     requeueCause != null ? new ThrowableCause(requeueCause) : cause,
+                                     diagnostics,
+                                     message);
+    }
+
+    @Override
+    public DeadLetter<M> withDiagnostics(MetaData diagnostics) {
+        return new MongoDeadLetter<>(index,
+                                     sequenceIdentifier,
+                                     enqueuedAt,
+                                     GenericDeadLetter.clock.instant(),
+                                     cause,
+                                     diagnostics,
+                                     message);
+    }
+
+    @Override
+    public String toString() {
+        return "JpaDeadLetter{" +
+                ", index=" + index +
+                ", sequenceIdentifier='" + sequenceIdentifier + "'" +
+                ", enqueuedAt=" + enqueuedAt +
+                ", lastTouched=" + lastTouched +
+                ", cause=" + cause +
+                ", diagnostics=" + diagnostics +
+                ", message=" + message +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MongoDeadLetter<?> that = (MongoDeadLetter<?>) o;
+
+        if (index != that.index) {
+            return false;
+        }
+        if (!sequenceIdentifier.equals(that.sequenceIdentifier)) {
+            return false;
+        }
+        if (!enqueuedAt.equals(that.enqueuedAt)) {
+            return false;
+        }
+        if (!lastTouched.equals(that.lastTouched)) {
+            return false;
+        }
+        if (!Objects.equals(cause, that.cause)) {
+            return false;
+        }
+        if (!Objects.equals(diagnostics, that.diagnostics)) {
+            return false;
+        }
+        return Objects.equals(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, sequenceIdentifier, enqueuedAt, lastTouched, cause, diagnostics, message);
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueue.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueue.java
@@ -1,0 +1,742 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.transaction.NoTransactionManager;
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.extensions.mongo.MongoTemplate;
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent.EventEntryConfiguration;
+import org.axonframework.messaging.Message;
+import org.axonframework.messaging.deadletter.Cause;
+import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.DeadLetterQueueOverflowException;
+import org.axonframework.messaging.deadletter.EnqueueDecision;
+import org.axonframework.messaging.deadletter.GenericDeadLetter;
+import org.axonframework.messaging.deadletter.NoSuchDeadLetterException;
+import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.WrongDeadLetterTypeException;
+import org.axonframework.serialization.Serializer;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import javax.annotation.Nonnull;
+
+import static java.util.Objects.isNull;
+import static org.axonframework.common.BuilderUtils.*;
+import static org.axonframework.extensions.mongo.eventhandling.deadletter.DeadLetterEntry.*;
+
+/**
+ * Mongo backed implementation of the {@link SequencedDeadLetterQueue}, used for storing dead letters containing
+ * {@link EventMessage Eventmessages} durably as a {@link DeadLetterEntry}.
+ * <p>
+ * Keeps the insertion order intact by saving an incremented index within each unique sequence, backed by the
+ * {@link DeadLetterEntry#getSequenceIdentifier()} property. Each sequence is uniquely identified by the sequence
+ * identifier, stored in the {@link DeadLetterEntry#getSequenceIdentifier()} field.
+ * <p>
+ * When processing an item, single execution across all applications is guaranteed by setting the
+ * {@link DeadLetterEntry#getProcessingStarted()} property, locking other processes out of the sequence for the
+ * configured {@code claimDuration} (30 seconds by default).
+ * <p>
+ * The stored {@link DeadLetterEntry entries} are converted to a {@link MongoDeadLetter} when they need to be processed
+ * or filtered. In order to restore the original {@link EventMessage} a matching {@link DeadLetterMongoConverter} is
+ * used. The default supports all {@code EventMessage} implementations provided by the framework. If you have a custom
+ * variant, you have to build your own.
+ * <p>
+ * {@link org.axonframework.serialization.upcasting.Upcaster upcasters} are not supported by this implementation, so
+ * breaking changes for events messages stored in the queue should be avoided.
+ *
+ * @param <M> An implementation of {@link Message} contained in the {@link DeadLetter dead-letters} within this queue.
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class MongoSequencedDeadLetterQueue<M extends EventMessage<?>> implements SequencedDeadLetterQueue<M> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final String processingGroup;
+    private final List<DeadLetterMongoConverter<EventMessage<?>>> converters;
+    private final EventEntryConfiguration eventConfiguration;
+    private final int maxSequences;
+    private final int maxSequenceSize;
+    private final MongoTemplate mongoTemplate;
+    private final Serializer serializer;
+    private final Duration claimDuration;
+    private final TransactionManager transactionManager;
+
+    /**
+     * Instantiate a Mongo {@link SequencedDeadLetterQueue} based on the given
+     * {@link MongoSequencedDeadLetterQueue.Builder builder}.
+     *
+     * @param builder The {@link MongoSequencedDeadLetterQueue.Builder} used to instantiate a
+     *                {@link MongoSequencedDeadLetterQueue} instance.
+     */
+    protected <T extends EventMessage<?>> MongoSequencedDeadLetterQueue(Builder<T> builder) {
+        builder.validate();
+        this.processingGroup = builder.processingGroup;
+        this.converters = builder.converters;
+        this.eventConfiguration = builder.eventConfiguration;
+        this.maxSequences = builder.maxSequences;
+        this.maxSequenceSize = builder.maxSequenceSize;
+        this.mongoTemplate = builder.mongoTemplate;
+        this.serializer = builder.serializer;
+        this.claimDuration = builder.claimDuration;
+        this.transactionManager = builder.transactionManager;
+        ensureDeadLetterIndexes(mongoTemplate.deadLetterCollection());
+    }
+
+    /**
+     * Creates a new builder, capable of building a {@link MongoSequencedDeadLetterQueue} according to the provided
+     * configuration. Note that the {@link MongoSequencedDeadLetterQueue.Builder#processingGroup(String)},
+     * {@link MongoSequencedDeadLetterQueue.Builder#mongoTemplate} and
+     * {@link MongoSequencedDeadLetterQueue.Builder#serializer(Serializer)} are mandatory for the queue to be
+     * constructed.
+     *
+     * @param <M> An implementation of {@link Message} contained in the {@link DeadLetter dead-letters} within this
+     *            queue.
+     * @return The builder
+     */
+    public static <M extends EventMessage<?>> MongoSequencedDeadLetterQueue.Builder<M> builder() {
+        return new MongoSequencedDeadLetterQueue.Builder<>();
+    }
+
+    @Override
+    public void enqueue(@Nonnull Object sequenceIdentifier, @Nonnull DeadLetter<? extends M> letter)
+            throws DeadLetterQueueOverflowException {
+        String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
+        if (isFull(stringSequenceIdentifier)) {
+            throw new DeadLetterQueueOverflowException(
+                    "No room left to enqueue [" + letter.message() + "] for identifier ["
+                            + stringSequenceIdentifier + "] since the queue is full."
+            );
+        }
+
+        Optional<Cause> optionalCause = letter.cause();
+        if (optionalCause.isPresent()) {
+            logger.info("Adding dead letter [{}] because [{}].", letter.message(), optionalCause.get());
+        } else {
+            logger.info("Adding dead letter [{}] because the sequence identifier [{}] is already present.",
+                        letter.message(), stringSequenceIdentifier);
+        }
+
+        DeadLetterEventEntry entry = converters
+                .stream()
+                .filter(c -> c.canConvert(letter.message()))
+                .findFirst()
+                .map(c -> c.convert(letter.message(), serializer))
+                .orElseThrow(() -> new NoMongoConverterFoundException(
+                        String.format("No converter found for message of type: [%s]",
+                                      letter.message().getClass().getName()))
+                );
+        Document message = entry.asDocument(eventConfiguration);
+        Long sequenceIndex = getNextIndexForSequence(stringSequenceIdentifier);
+        logger.info("Storing DeadLetter (id: [{}]) for sequence [{}] with index [{}] in processing group [{}].",
+                    entry.getEventIdentifier(),
+                    stringSequenceIdentifier,
+                    sequenceIndex,
+                    processingGroup);
+        DeadLetterEntry deadLetter = new DeadLetterEntry(
+                processingGroup,
+                stringSequenceIdentifier,
+                sequenceIndex,
+                message,
+                letter.enqueuedAt(),
+                letter.lastTouched(),
+                letter.cause().orElse(null),
+                letter.diagnostics(),
+                serializer);
+        Document document = deadLetter.asDocument();
+        transactionManager.executeInTransaction(
+                () -> mongoTemplate.deadLetterCollection().insertOne(document)
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void evict(DeadLetter<? extends M> letter) {
+        if (!(letter instanceof MongoDeadLetter)) {
+            throw new WrongDeadLetterTypeException(
+                    String.format("Evict should be called with a MongoDeadLetter instance. Instead got: [%s]",
+                                  letter.getClass().getName()));
+        }
+        MongoDeadLetter<M> deadLetter = (MongoDeadLetter<M>) letter;
+        if (logger.isInfoEnabled()) {
+            logger.info("Trying to evict MongoDeadLetter with processing group {} sequence {} and index {}",
+                        processingGroup,
+                        deadLetter.sequenceIdentifier(),
+                        deadLetter.index());
+        }
+        DeleteResult result = transactionManager.fetchInTransaction(
+                () -> mongoTemplate.deadLetterCollection().deleteOne(findOneFilter(
+                        processingGroup,
+                        deadLetter.sequenceIdentifier(),
+                        deadLetter.index()))
+        );
+        if (logger.isInfoEnabled()) {
+            if (result.getDeletedCount() == 1) {
+                logger.info("Successfully evict MongoDeadLetter with processing group {} sequence {} and index {}",
+                            processingGroup,
+                            deadLetter.sequenceIdentifier(),
+                            deadLetter.index());
+            } else {
+                logger.info(
+                        "Failed to evict MongoDeadLetter with processing group {} sequence {} and index {} with result {}",
+                        processingGroup,
+                        deadLetter.sequenceIdentifier(),
+                        deadLetter.index(),
+                        result);
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void requeue(@Nonnull DeadLetter<? extends M> letter,
+                        @Nonnull UnaryOperator<DeadLetter<? extends M>> letterUpdater)
+            throws NoSuchDeadLetterException {
+        if (!(letter instanceof MongoDeadLetter)) {
+            throw new WrongDeadLetterTypeException(String.format(
+                    "Requeue should be called with a MongoDeadLetter instance. Instead got: [%s]",
+                    letter.getClass().getName()));
+        }
+        DeadLetter<? extends M> updatedLetter = letterUpdater.apply(letter).markTouched();
+        MongoDeadLetter<? extends M> mongoDeadLetter = (MongoDeadLetter<? extends M>) letter;
+        Document letterEntityDocument = transactionManager.fetchInTransaction(
+                () -> mongoTemplate
+                        .deadLetterCollection()
+                        .find(findOneFilter(
+                                processingGroup,
+                                mongoDeadLetter.sequenceIdentifier(),
+                                mongoDeadLetter.index()))
+                        .first()
+        );
+        if (letterEntityDocument == null) {
+            throw new NoSuchDeadLetterException(
+                    String.format(
+                            "Can not find dead letter with processing group [%s], sequence identifier [%s] and index [%s] to requeue.",
+                            processingGroup,
+                            mongoDeadLetter.sequenceIdentifier(),
+                            mongoDeadLetter.index()));
+        }
+        DeadLetterEntry letterEntity = new DeadLetterEntry(letterEntityDocument);
+        letterEntity.setDiagnostics(updatedLetter.diagnostics(), serializer);
+        letterEntity.setLastTouched(updatedLetter.lastTouched());
+        updatedLetter.cause().ifPresent(letterEntity::setCause);
+        letterEntity.clearProcessingStarted();
+        if (logger.isInfoEnabled()) {
+            logger.info(
+                    "Requeueing dead letter with processing group [{}], sequence identifier [{}] and index [{}] with cause [{}]",
+                    processingGroup,
+                    mongoDeadLetter.sequenceIdentifier(),
+                    mongoDeadLetter.index(),
+                    updatedLetter.cause());
+        }
+        transactionManager.executeInTransaction(
+                () -> mongoTemplate.deadLetterCollection().findOneAndReplace(
+                        findOneFilter(
+                                processingGroup,
+                                mongoDeadLetter.sequenceIdentifier(),
+                                mongoDeadLetter.index()),
+                        letterEntity.asDocument()
+                )
+        );
+    }
+
+    @Override
+    public boolean contains(@Nonnull Object sequenceIdentifier) {
+        String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
+        return sequenceSize(stringSequenceIdentifier) > 0;
+    }
+
+    @Override
+    public Iterable<DeadLetter<? extends M>> deadLetterSequence(@Nonnull Object sequenceIdentifier) {
+        String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
+        return transactionManager.fetchInTransaction(
+                () -> mongoTemplate.deadLetterCollection()
+                                   .find(processingGroupAndSequenceIdentifierFilter(processingGroup,
+                                                                                    stringSequenceIdentifier))
+                                   .sort(indexSortAscending())
+                                   .map(DeadLetterEntry::new)
+                                   .map(this::toLetter)
+        );
+    }
+
+    @Override
+    public Iterable<Iterable<DeadLetter<? extends M>>> deadLetters() {
+        return transactionManager.fetchInTransaction(
+                () -> sequenceIdentifierIterator(mongoTemplate.deadLetterCollection(), processingGroup)
+                        .map(sequenceIdentifier -> {
+                            assertNonNull(sequenceIdentifier, "SequenceIdentifier can not be null.");
+                            return deadLetterSequence(sequenceIdentifier);
+                        })
+        );
+    }
+
+    /**
+     * Converts a {@link DeadLetterEntry} from the database into a {@link MongoDeadLetter}, using the configured
+     * {@link DeadLetterMongoConverter DeadLetterMongoConverters} to restore the original message from it.
+     *
+     * @param entry The entry to convert.
+     * @return The {@link DeadLetter} result.
+     */
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    private MongoDeadLetter<M> toLetter(DeadLetterEntry entry) {
+        DeadLetterEventEntry deadLetterEventEntry = entry.getMessage(eventConfiguration);
+        DeadLetterMongoConverter<M> converter = (DeadLetterMongoConverter<M>) converters
+                .stream()
+                .filter(c -> c.canConvert(deadLetterEventEntry))
+                .findFirst()
+                .orElseThrow(() -> new NoMongoConverterFoundException(String.format(
+                        "No converter found to convert message of class [%s].",
+                        deadLetterEventEntry.getMessageType())));
+        return new MongoDeadLetter<>(entry,
+                                     serializer.deserialize(entry.getDiagnostics()),
+                                     converter.convert(deadLetterEventEntry, serializer));
+    }
+
+    @Override
+    public boolean isFull(@Nonnull Object sequenceIdentifier) {
+        String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
+        long numberInSequence = sequenceSize(stringSequenceIdentifier);
+        if (numberInSequence > 0) {
+            // Is already in queue, cannot cause overflow any longer.
+            return numberInSequence >= maxSequenceSize;
+        }
+        return amountOfSequences() >= maxSequences;
+    }
+
+    @Override
+    public long size() {
+        return transactionManager.fetchInTransaction(
+                () -> mongoTemplate.deadLetterCollection()
+                                   .countDocuments(processingGroupFilter(processingGroup))
+        );
+    }
+
+    @Override
+    public long sequenceSize(@Nonnull Object sequenceIdentifier) {
+        String identifier = toStringSequenceIdentifier(sequenceIdentifier);
+        return transactionManager.fetchInTransaction(
+                () -> mongoTemplate.deadLetterCollection()
+                                   .countDocuments(processingGroupAndSequenceIdentifierFilter(processingGroup,
+                                                                                              identifier))
+        );
+    }
+
+    @Override
+    public long amountOfSequences() {
+        AtomicLong counter = new AtomicLong(0L);
+        transactionManager.executeInTransaction(
+                () -> sequenceIdentifierIterator(mongoTemplate.deadLetterCollection(), processingGroup)
+                        .forEach(i -> counter.incrementAndGet())
+        );
+        return counter.get();
+    }
+
+    @Override
+    public boolean process(@Nonnull Predicate<DeadLetter<? extends M>> sequenceFilter,
+                           @Nonnull Function<DeadLetter<? extends M>, EnqueueDecision<M>> processingTask) {
+        final AtomicReference<MongoDeadLetter<M>> claimedLetter = new AtomicReference<>();
+        transactionManager.executeInTransaction(
+                () -> {
+                    try (MongoCursor<Document> iterator = mongoTemplate
+                            .deadLetterCollection()
+                            .aggregate(firstNotLockedFilter(processingGroup, getProcessingStartedLimit()))
+                            .iterator()) {
+                        while (iterator.hasNext() && claimedLetter.get() == null) {
+                            Document id = iterator.next();
+                            Document document = mongoTemplate.deadLetterCollection().find(id).first();
+                            if (isNull(document) || isLocked(getProcessingStartedLimit(), document)) {
+                                continue;
+                            }
+                            MongoDeadLetter<M> current = toLetter(new DeadLetterEntry(document));
+                            if (sequenceFilter.test(current) && claimDeadLetter(current)) {
+                                claimedLetter.set(current);
+                            }
+                        }
+                    }
+                });
+        if (claimedLetter.get() != null) {
+            return processLetterAndFollowing(claimedLetter.get(), processingTask);
+        }
+        logger.info("No claimable and/or matching dead letters found to process.");
+        return false;
+    }
+
+    /**
+     * Processes the given {@code firstDeadLetter} using the provided {@code processingTask}. When successful (the
+     * message is evicted) it will automatically process all messages in the same
+     * {@link MongoDeadLetter#sequenceIdentifier()}, evicting messages that succeed and stopping when the first one
+     * fails (and is requeued).
+     * <p>
+     * Will claim the next letter in the same sequence before removing the old one to prevent concurrency issues.
+     *
+     * @param firstDeadLetter The dead letter to start processing.
+     * @param processingTask  The task to use to process the dead letter, providing a decision afterwards.
+     * @return Whether processing all letters in this sequence was successful.
+     */
+    private boolean processLetterAndFollowing(MongoDeadLetter<M> firstDeadLetter,
+                                              Function<DeadLetter<? extends M>, EnqueueDecision<M>> processingTask) {
+        MongoDeadLetter<M> deadLetter = firstDeadLetter;
+        while (deadLetter != null) {
+            if (logger.isInfoEnabled()) {
+                logger.info("Processing dead letter with sequence identifier [{}] and index [{}]",
+                            deadLetter.sequenceIdentifier(),
+                            deadLetter.index());
+            }
+            EnqueueDecision<M> decision = processingTask.apply(deadLetter);
+            if (!decision.shouldEnqueue()) {
+                MongoDeadLetter<M> oldLetter = deadLetter;
+                Document deadLetterDocument = findNextDeadLetter(oldLetter);
+                if (deadLetterDocument != null) {
+                    deadLetter = toLetter(new DeadLetterEntry(deadLetterDocument));
+                    claimDeadLetter(deadLetter);
+                } else {
+                    deadLetter = null;
+                }
+                evict(oldLetter);
+            } else {
+                requeue(deadLetter,
+                        l -> decision.withDiagnostics(l)
+                                     .withCause(decision.enqueueCause().orElse(null))
+                );
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Finds the next dead letter after the provided {@code oldLetter} in the database. This is the message in the same
+     * {@code processingGroup} and {@code sequence}, but with the next index.
+     *
+     * @param oldLetter The base letter to search from.
+     * @return The next letter to process.
+     */
+    private Document findNextDeadLetter(MongoDeadLetter<M> oldLetter) {
+        return transactionManager.fetchInTransaction(
+                () -> mongoTemplate
+                        .deadLetterCollection()
+                        .find(nextItemInSequenceFilter(processingGroup,
+                                                       oldLetter.sequenceIdentifier(),
+                                                       oldLetter.index()))
+                        .sort(indexSortAscending())
+                        .limit(1)
+                        .first()
+        );
+    }
+
+    /**
+     * Claims the provided {@link DeadLetter} in the database by setting the {@code processingStarted} property. Will
+     * check whether it was claimed successfully and return an appropriate boolean result.
+     *
+     * @return Whether the letter was successfully claimed or not.
+     */
+    private boolean claimDeadLetter(MongoDeadLetter<M> deadLetter) {
+        Instant processingStartedLimit = getProcessingStartedLimit();
+        UpdateResult result = transactionManager.fetchInTransaction(
+                () -> mongoTemplate.deadLetterCollection().updateOne(
+                        uniqueNotLockedFilter(
+                                processingGroup,
+                                deadLetter.sequenceIdentifier(),
+                                deadLetter.index(),
+                                processingStartedLimit),
+                        updateProcessingStarted(GenericDeadLetter.clock.instant()))
+        );
+
+        if (result.getMatchedCount() > 0) {
+            logger.info("Claimed dead letter with id [{}] to process.", result.getUpsertedId());
+            return true;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("Failed to claim dead letter with sequence identifier [{}] and index [{}].",
+                        deadLetter.sequenceIdentifier(),
+                        deadLetter.index());
+        }
+        return false;
+    }
+
+    /**
+     * Determines the time the {@link DeadLetterEntry#getProcessingStarted()} needs to at least have to stay claimed.
+     * This is based on the configured {@link #claimDuration}.
+     */
+    private Instant getProcessingStartedLimit() {
+        return GenericDeadLetter.clock.instant().minus(claimDuration);
+    }
+
+    @Override
+    public void clear() {
+        transactionManager.executeInTransaction(
+                () -> mongoTemplate.deadLetterCollection().deleteMany(processingGroupFilter(processingGroup))
+        );
+    }
+
+    /**
+     * Fetches the next maximum index for a sequence that should be used when inserting a new item into the database for
+     * this {@code sequence}.
+     *
+     * @param sequenceIdentifier The identifier of the sequence to fetch the next index for.
+     * @return The next sequence index.
+     */
+    private Long getNextIndexForSequence(String sequenceIdentifier) {
+        Long maxIndex = getMaxIndexForSequence(sequenceIdentifier);
+        if (maxIndex == null) {
+            return 0L;
+        }
+        return maxIndex + 1;
+    }
+
+    /**
+     * Fetches the current maximum index for a queue identifier. Messages which are enqueued next should have an index
+     * higher than the one returned. If the query returns null it indicates that the queue is empty.
+     *
+     * @param sequenceIdentifier The identifier of the sequence to check the index for.
+     * @return The current maximum index, or null if not present.
+     */
+    private Long getMaxIndexForSequence(String sequenceIdentifier) {
+        Document deadLetterEntry = transactionManager.fetchInTransaction(
+                () -> mongoTemplate
+                        .deadLetterCollection()
+                        .find(processingGroupAndSequenceIdentifierFilter(processingGroup, sequenceIdentifier))
+                        .sort(indexSortDescending())
+                        .limit(1)
+                        .first()
+        );
+        return index(deadLetterEntry);
+    }
+
+    /**
+     * Converts the given sequence identifier to a String.
+     */
+    private String toStringSequenceIdentifier(Object sequenceIdentifier) {
+        if (sequenceIdentifier instanceof String) {
+            return (String) sequenceIdentifier;
+        }
+        return Integer.toString(sequenceIdentifier.hashCode());
+    }
+
+    /**
+     * Builder class to instantiate an {@link MongoSequencedDeadLetterQueue}.
+     * <p>
+     * The maximum number of unique sequences defaults to {@code 1024}, the maximum amount of dead letters inside a
+     * unique sequence to {@code 1024}, the claim duration defaults to {@code 30} seconds, the query page size defaults
+     * to {@code 100}, and the converters default to containing a single {@link EventMessageDeadLetterMongoConverter}.
+     * <p>
+     * If you have custom {@link EventMessage} to use with this queue, replace the current (or add a second) converter.
+     * <p>
+     * The {@link TransactionManager} is defaulted to a {@link NoTransactionManager}.
+     * <p>
+     * The {@code processingGroup}, {@link MongoTemplate}, and {@link Serializer} have to be configured for the
+     * {@link MongoSequencedDeadLetterQueue} to be constructed.
+     *
+     * @param <T> The type of {@link Message} maintained in this {@link MongoSequencedDeadLetterQueue}.
+     */
+    public static class Builder<T extends EventMessage<?>> {
+
+        private final List<DeadLetterMongoConverter<EventMessage<?>>> converters = new LinkedList<>();
+        private EventEntryConfiguration eventConfiguration = EventEntryConfiguration.getDefault();
+        private String processingGroup = null;
+        private int maxSequences = 1024;
+        private int maxSequenceSize = 1024;
+        private MongoTemplate mongoTemplate;
+        private Serializer serializer;
+        private Duration claimDuration = Duration.ofSeconds(30);
+        private TransactionManager transactionManager = NoTransactionManager.instance();
+
+        public Builder() {
+            converters.add(new EventMessageDeadLetterMongoConverter());
+        }
+
+        /**
+         * Sets the processing group, which is used for storing and querying which event processor the deadlettered item
+         * belonged to.
+         *
+         * @param processingGroup The processing group of this {@link SequencedDeadLetterQueue}.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> processingGroup(String processingGroup) {
+            assertNonEmpty(processingGroup, "Can not set processingGroup to an empty String.");
+            this.processingGroup = processingGroup;
+            return this;
+        }
+
+        /**
+         * Sets the event configuration, which is used for storing the events
+         *
+         * @param eventConfiguration The event configuration of this {@link SequencedDeadLetterQueue}.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> eventConfiguration(EventEntryConfiguration eventConfiguration) {
+            assertNonNull(eventConfiguration, "EventEntryConfiguration may not be null");
+            this.eventConfiguration = eventConfiguration;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of unique sequences this {@link SequencedDeadLetterQueue} may contain.
+         * <p>
+         * The given {@code maxSequences} is required to be a positive number, higher or equal to {@code 128}. It
+         * defaults to {@code 1024}.
+         *
+         * @param maxSequences The maximum amount of unique sequences for the queue under construction.
+         * @return The current Builder, for fluent interfacing.
+         */
+        public Builder<T> maxSequences(int maxSequences) {
+            assertStrictPositive(maxSequences,
+                                 "The maximum number of sequences should be larger or equal to 0");
+            this.maxSequences = maxSequences;
+            return this;
+        }
+
+        /**
+         * Sets the maximum amount of {@link DeadLetter letters} per unique sequences this
+         * {@link SequencedDeadLetterQueue} can store.
+         * <p>
+         * The given {@code maxSequenceSize} is required to be a positive number, higher or equal to {@code 128}. It
+         * defaults to {@code 1024}.
+         *
+         * @param maxSequenceSize The maximum amount of {@link DeadLetter letters} per unique  sequence.
+         * @return The current Builder, for fluent interfacing.
+         */
+        public Builder<T> maxSequenceSize(int maxSequenceSize) {
+            assertStrictPositive(maxSequenceSize,
+                                 "The maximum number of entries in a sequence should be larger or equal to 128");
+            this.maxSequenceSize = maxSequenceSize;
+            return this;
+        }
+
+        /**
+         * Sets the {@link MongoTemplate} providing access to the collections.
+         *
+         * @param mongoTemplate the {@link MongoTemplate} providing access to the collections
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> mongoTemplate(MongoTemplate mongoTemplate) {
+            assertNonNull(mongoTemplate, "MongoTemplate may not be null");
+            this.mongoTemplate = mongoTemplate;
+            return this;
+        }
+
+        /**
+         * Sets the {@link Serializer} to deserialize the events, metadata and diagnostics of the {@link DeadLetter}
+         * when storing it to a database.
+         *
+         * @param serializer The serializer to use
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> serializer(Serializer serializer) {
+            assertNonNull(serializer, "The serializer may not be null");
+            this.serializer = serializer;
+            return this;
+        }
+
+        /**
+         * Removes all current converters currently configured, including the default
+         * {@link EventMessageDeadLetterMongoConverter}.
+         *
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> clearConverters() {
+            this.converters.clear();
+            return this;
+        }
+
+        /**
+         * Adds a {@link DeadLetterMongoConverter} to the configuration, which is used to deserialize dead-letter
+         * entries from the database.
+         *
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> addConverter(
+                DeadLetterMongoConverter<EventMessage<?>> converter) {
+            assertNonNull(converter, "Can not add a null DeadLetterMongoConverter.");
+            this.converters.add(converter);
+            return this;
+        }
+
+        /**
+         * Sets the claim duration, which is the time a message gets locked when processing and waiting for it to
+         * complete. Other invocations of the {@link #process(Predicate, Function)} method will be unable to process a
+         * sequence while the claim is active. Its default is 30 seconds.
+         * <p>
+         * Claims are automatically released once the item is requeued, the claim time is a backup policy in case of
+         * unforeseen trouble such as down database connections.
+         *
+         * @param claimDuration The longest claim duration allowed.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> claimDuration(Duration claimDuration) {
+            assertNonNull(claimDuration, "Claim duration can not be set to null.");
+            this.claimDuration = claimDuration;
+            return this;
+        }
+
+        /**
+         * Sets the {@link TransactionManager} used to manage transaction around fetching tokens. Will default to
+         * {@link NoTransactionManager}, which effectively will not use transactions.
+         *
+         * @param transactionManager a {@link TransactionManager} used to manage transaction around fetching event data
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<T> transactionManager(TransactionManager transactionManager) {
+            assertNonNull(transactionManager, "TransactionManager may not be null");
+            this.transactionManager = transactionManager;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link MongoSequencedDeadLetterQueue} as specified through this Builder.
+         *
+         * @return A {@link MongoSequencedDeadLetterQueue} as specified through this Builder.
+         */
+        public MongoSequencedDeadLetterQueue<T> build() {
+            return new MongoSequencedDeadLetterQueue<>(this);
+        }
+
+        /**
+         * Validate whether the fields contained in this Builder are set accordingly.
+         *
+         * @throws AxonConfigurationException When one field asserts to be incorrect according to the Builder's
+         *                                    specifications.
+         */
+        protected void validate() {
+            assertNonEmpty(processingGroup,
+                           "Must supply processingGroup when constructing a MongoSequencedDeadLetterQueue");
+            assertNonNull(mongoTemplate,
+                          "Must supply a Mongo template when constructing a MongoSequencedDeadLetterQueue");
+            assertNonNull(serializer,
+                          "Must supply a Serializer when constructing a MongoSequencedDeadLetterQueue");
+        }
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/NoMongoConverterFoundException.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/NoMongoConverterFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.common.AxonException;
+
+/**
+ * Indicates that the {@link MongoSequencedDeadLetterQueue} could not resolve a converter based on the
+ * {@link DeadLetterEntry} or {@link org.axonframework.eventhandling.EventMessage} that needed to be converted.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class NoMongoConverterFoundException extends AxonException {
+
+    /**
+     * Constructs a {@code NoMongoConverterFoundException} with the provided {@code message}.
+     *
+     * @param message The message containing more details about the cause.
+     */
+    public NoMongoConverterFoundException(String message) {
+        super(message);
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/NotAnInstantDocumentException.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/NotAnInstantDocumentException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.common.AxonException;
+
+/**
+ * Indicates that the {@link org.bson.Document} did not contain the keys expected of an {@link InstantEntry}.
+ *
+ * @author Gerard Klijs
+ * @since 4.7.0
+ */
+public class NotAnInstantDocumentException extends AxonException {
+
+    /**
+     * Constructs a {@code NoMongoConverterFoundException} with the provided {@code message}.
+     *
+     * @param message The message containing more details about the cause.
+     */
+    public NotAnInstantDocumentException(String message) {
+        super(message);
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/documentperevent/EventEntry.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/documentperevent/EventEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.axonframework.serialization.SimpleSerializedObject;
 import org.bson.Document;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import static org.axonframework.common.DateTimeUtils.formatInstant;
 
@@ -156,5 +157,61 @@ public class EventEntry implements DomainEventData<Object> {
             representationType = Document.class;
         }
         return representationType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EventEntry that = (EventEntry) o;
+
+        if (!Objects.equals(getEventIdentifier(), that.getEventIdentifier())) {
+            return false;
+        }
+        if (!Objects.equals(getTimestamp(), that.getTimestamp())) {
+            return false;
+        }
+        if (!Objects.equals(getPayload(), that.getPayload())) {
+            return false;
+        }
+        if (!Objects.equals(getMetaData(), that.getMetaData())) {
+            return false;
+        }
+        if (!Objects.equals(getType(), that.getType())) {
+            return false;
+        }
+        if (!Objects.equals(getAggregateIdentifier(), that.getAggregateIdentifier())) {
+            return false;
+        }
+        return Objects.equals(getSequenceNumber(), that.getSequenceNumber());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getEventIdentifier(),
+                            getTimestamp(),
+                            getPayload(),
+                            getMetaData(),
+                            getType(),
+                            getAggregateIdentifier(),
+                            getSequenceNumber());
+    }
+
+    @Override
+    public String toString() {
+        return "EventEntry{" +
+                ", eventIdentifier='" + getEventIdentifier() + '\'' +
+                ", timeStamp='" + getTimestamp() + '\'' +
+                ", payload='" + getPayload() + '\'' +
+                ", metaData=" + getMetaData() +
+                ", type='" + getType() + '\'' +
+                ", aggregateIdentifier='" + getAggregateIdentifier() + '\'' +
+                ", sequenceNumber=" + getSequenceNumber() +
+                '}';
     }
 }

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/DefaultMongoTemplateTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/DefaultMongoTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,18 @@ class DefaultMongoTemplateTest {
 
         verify(mockMongo).getDatabase("customDatabaseName");
         testSubject.trackingTokensCollection();
+        verify(mockDb).getCollection("customCollectionName");
+    }
+
+    @Test
+    void ifDeadLetterCollectionIsSetThenItShouldBeUsedInsteadOfTheDefault() {
+        testSubject = DefaultMongoTemplate.builder()
+                                          .mongoDatabase(mockMongo, "customDatabaseName")
+                                          .build()
+                                          .withDeadLetterCollection("customCollectionName");
+
+        verify(mockMongo).getDatabase("customDatabaseName");
+        testSubject.deadLetterCollection();
         verify(mockDb).getCollection("customCollectionName");
     }
 

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEntryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEntryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent.EventEntryConfiguration;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeadLetterEntryTest {
+
+    @Test
+    void equalsHashcodeAndToStringShouldWorkCorrectly() {
+        DeadLetterEntry original = testEntry();
+        DeadLetterEntry copy = new DeadLetterEntry(original.asDocument());
+        assertEquals(original, copy);
+        assertEquals(original.hashCode(), copy.hashCode());
+        assertEquals(original.toString(), copy.toString());
+    }
+
+    static DeadLetterEntry testEntry() {
+        return new DeadLetterEntry(
+                "processingGroup",
+                "seqIdentifier",
+                0L,
+                DeadLetterEventEntryTest.testEntry().asDocument(EventEntryConfiguration.getDefault()),
+                Instant.now().minus(Duration.ofMinutes(3L)),
+                Instant.now(),
+                null,
+                null,
+                TestSerializer.JACKSON.getSerializer()
+        );
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEventEntryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/DeadLetterEventEntryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent.EventEntryConfiguration;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeadLetterEventEntryTest {
+
+    @Test
+    void equalsHashcodeAndToStringShouldWorkCorrectly() {
+        DeadLetterEventEntry original = testEntry();
+        DeadLetterEventEntry copy = new DeadLetterEventEntry(original.asDocument(EventEntryConfiguration.getDefault()),
+                                                             EventEntryConfiguration.getDefault());
+        assertEquals(original, copy);
+        assertEquals(original.hashCode(), copy.hashCode());
+        assertEquals(original.toString(), copy.toString());
+    }
+
+    static DeadLetterEventEntry testEntry() {
+        return DeadLetterEventEntry
+                .fromEventMessage(
+                        GenericEventMessage.asEventMessage("foo"),
+                        TestSerializer.JACKSON.getSerializer()
+                );
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/EventMessageDeadLetterMongoConverterTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/EventMessageDeadLetterMongoConverterTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GapAwareTrackingToken;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
+import org.axonframework.eventhandling.GenericTrackedEventMessage;
+import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.Revision;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventMessageDeadLetterMongoConverterTest {
+
+    private static final String PAYLOAD_REVISION = "23.0";
+    private final EventMessageDeadLetterMongoConverter converter = new EventMessageDeadLetterMongoConverter();
+    private final Serializer serializer = TestSerializer.JACKSON.getSerializer();
+    private final ConverterTestEvent event = new ConverterTestEvent("myValue");
+    private final MetaData metaData = MetaData.from(Collections.singletonMap("myMetadataKey", "myMetadataValue"));
+
+    @Test
+    void canConvertGenericEventMessageAndBackCorrectly() {
+        testConversion(GenericEventMessage.asEventMessage(event).andMetaData(metaData));
+    }
+
+    @Test
+    void canConvertDomainEventMessageAndBackCorrectly() {
+        testConversion(new GenericDomainEventMessage<>("MyType", "8239081092", 25L, event, metaData));
+    }
+
+    @Test
+    void canConvertTrackedDomainEventMessageWithGlobalSequenceTokenAndBackCorrectly() {
+        testConversion(new GenericTrackedDomainEventMessage<>(new GlobalSequenceTrackingToken(232323L),
+                                                              "MyType",
+                                                              "8239081092",
+                                                              25L,
+                                                              new GenericEventMessage<>(event, metaData),
+                                                              Instant::now));
+    }
+
+    @Test
+    void canConvertTrackedDomainEventMessageWithGapAwareTokenAndBackCorrectly() {
+        testConversion(new GenericTrackedDomainEventMessage<>(new GapAwareTrackingToken(232323L, Arrays.asList(24L, 255L, 2225L)),
+                                                              "MyType",
+                                                              "8239081092",
+                                                              25L,
+                                                              new GenericEventMessage<>(event, metaData),
+                                                              Instant::now));
+    }
+
+    @Test
+    void canConvertTrackedEventMessageWithGlobalSequenceTokenAndBackCorrectly() {
+        testConversion(new GenericTrackedEventMessage<>(new GlobalSequenceTrackingToken(232323L),
+                                                        new GenericEventMessage<>(event, metaData),
+                                                        Instant::now));
+    }
+
+
+    @Test
+    void canConvertTrackedEventMessageWithGapAwareTokenAndBackCorrectly() {
+        testConversion(new GenericTrackedEventMessage<>(new GapAwareTrackingToken(232323L, Arrays.asList(24L, 255L, 2225L)),
+                                                        new GenericEventMessage<>(event, metaData),
+                                                        Instant::now));
+    }
+
+    private void testConversion(EventMessage<?> message) {
+        assertTrue(converter.canConvert(message));
+        DeadLetterEventEntry deadLetterEventEntry = converter.convert(message, serializer);
+
+        assertCorrectlyMapped(message, deadLetterEventEntry);
+        assertTrue(converter.canConvert(deadLetterEventEntry));
+
+        EventMessage<?> restoredEventMessage = converter.convert(deadLetterEventEntry, serializer);
+        assertCorrectlyRestored(message, restoredEventMessage);
+    }
+
+    private void assertCorrectlyRestored(EventMessage<?> expected, EventMessage<?> actual) {
+        assertEquals(expected.getIdentifier(), actual.getIdentifier());
+        assertEquals(expected.getTimestamp().toEpochMilli(), actual.getTimestamp().toEpochMilli());
+        assertEquals(expected.getPayload(), actual.getPayload());
+        assertEquals(expected.getPayloadType(), actual.getPayloadType());
+        assertEquals(expected.getMetaData(), actual.getMetaData());
+
+        assertEquals(expected.getClass(), actual.getClass());
+        if (expected instanceof DomainEventMessage) {
+            DomainEventMessage<?> domainExpected = (DomainEventMessage<?>) expected;
+            DomainEventMessage<?> domainActual = (DomainEventMessage<?>) actual;
+
+            assertEquals(domainExpected.getType(), domainActual.getType());
+            assertEquals(domainExpected.getAggregateIdentifier(), domainActual.getAggregateIdentifier());
+            assertEquals(domainExpected.getSequenceNumber(), domainActual.getSequenceNumber());
+        }
+        if (expected instanceof TrackedEventMessage) {
+            TrackedEventMessage<?> trackedExpected = (TrackedEventMessage<?>) expected;
+            TrackedEventMessage<?> trackedActual = (TrackedEventMessage<?>) actual;
+
+            assertEquals(trackedExpected.trackingToken(), trackedActual.trackingToken());
+        }
+    }
+
+    private void assertCorrectlyMapped(EventMessage<?> eventMessage, DeadLetterEventEntry deadLetterEventEntry) {
+        assertEquals(eventMessage.getIdentifier(), deadLetterEventEntry.getEventIdentifier());
+        assertEquals(eventMessage.getTimestamp().toEpochMilli(), deadLetterEventEntry.getTimestamp().toEpochMilli());
+        assertEquals(eventMessage.getPayload().getClass().getName(),
+                     deadLetterEventEntry.getPayload().getType().getName());
+        assertEquals(PAYLOAD_REVISION, deadLetterEventEntry.getPayload().getType().getRevision());
+        assertEquals(serializer.serialize(event, String.class).getData(),
+                     deadLetterEventEntry.getPayload().getData());
+        assertEquals(MetaData.class.getName(), deadLetterEventEntry.getMetaData().getType().getName());
+        assertEquals(serializer.serialize(metaData, String.class).getData(),
+                     deadLetterEventEntry.getMetaData().getData());
+
+        if (eventMessage instanceof DomainEventMessage) {
+            DomainEventMessage<?> domainEventMessage = (DomainEventMessage<?>) eventMessage;
+            assertEquals(domainEventMessage.getType(), deadLetterEventEntry.getType());
+            assertEquals(domainEventMessage.getAggregateIdentifier(), deadLetterEventEntry.getAggregateIdentifier());
+            assertEquals(domainEventMessage.getSequenceNumber(), deadLetterEventEntry.getSequenceNumber());
+        } else {
+            assertNull(deadLetterEventEntry.getType());
+            assertNull(deadLetterEventEntry.getAggregateIdentifier());
+        }
+        if (eventMessage instanceof TrackedEventMessage) {
+            TrackedEventMessage<?> trackedEventMessage = (TrackedEventMessage<?>) eventMessage;
+            assertEquals(trackedEventMessage.trackingToken().getClass().getName(),
+                         deadLetterEventEntry.getTrackingToken().getType().getName());
+            assertEquals(serializer.serialize(trackedEventMessage.trackingToken(), String.class).getData(),
+                         new String(deadLetterEventEntry.getTrackingToken().getData()));
+        } else {
+            assertNull(deadLetterEventEntry.getTrackingToken());
+        }
+    }
+
+    @Revision(EventMessageDeadLetterMongoConverterTest.PAYLOAD_REVISION)
+    public static class ConverterTestEvent {
+
+        private final String myProperty;
+
+        @JsonCreator
+        public ConverterTestEvent(@JsonProperty("myProperty") String myProperty) {
+            this.myProperty = myProperty;
+        }
+
+        public String getMyProperty() {
+            return myProperty;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ConverterTestEvent that = (ConverterTestEvent) o;
+
+            return Objects.equals(myProperty, that.myProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            return myProperty != null ? myProperty.hashCode() : 0;
+        }
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/InstantEntryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/InstantEntryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InstantEntryTest {
+
+    @Test
+    void shouldThrowWhenCallingConstructorWithDocumentAndKeysDontMatch() {
+        Document document = new Document();
+        assertThrows(NotAnInstantDocumentException.class, () -> new InstantEntry(document));
+    }
+
+    @Test
+    void givenAnInstantWhenConvertedToADocumentAndBackToInstantItShouldBeTheSame() {
+        Instant given = Instant.now();
+
+        Document asDocument = new InstantEntry(given).asDocument();
+        assertEquals(given, new InstantEntry(asDocument).getInstant());
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoDeadLetteringIntegrationTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoDeadLetteringIntegrationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import com.mongodb.BasicDBObject;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.deadletter.DeadLetteringEventIntegrationTest;
+import org.axonframework.extensions.mongo.MongoTemplate;
+import org.axonframework.extensions.mongo.util.MongoTemplateFactory;
+import org.axonframework.extensions.mongo.utils.TestSerializer;
+import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class MongoDeadLetteringIntegrationTest extends DeadLetteringEventIntegrationTest {
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER = new MongoDBContainer("mongo:5");
+    private static final String PROCESSING_GROUP = "processing-group";
+    private static final int MAX_SEQUENCES_AND_SEQUENCE_SIZE = 128;
+
+    @Override
+    protected SequencedDeadLetterQueue<EventMessage<?>> buildDeadLetterQueue() {
+        MongoTemplate mongoTemplate = MongoTemplateFactory.build(
+                MONGO_CONTAINER.getHost(), MONGO_CONTAINER.getFirstMappedPort()
+        );
+        mongoTemplate.deadLetterCollection().deleteMany(new BasicDBObject());
+        return MongoSequencedDeadLetterQueue
+                .builder()
+                .processingGroup(PROCESSING_GROUP)
+                .maxSequences(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .maxSequenceSize(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .serializer(TestSerializer.xStreamSerializer())
+                .mongoTemplate(mongoTemplate)
+                .build();
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueueBuilderTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueueBuilderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.extensions.mongo.MongoTemplate;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MongoSequencedDeadLetterQueueBuilderTest {
+
+    private final MongoTemplate mongoTemplate = mock(MongoTemplate.class);
+
+    @Test
+    void buildWithNegativeMaxQueuesThrowsAxonConfigurationException() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builderTestSubject = MongoSequencedDeadLetterQueue.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.maxSequences(-1));
+    }
+
+    @Test
+    void buildWithZeroMaxQueuesThrowsAxonConfigurationException() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builderTestSubject = MongoSequencedDeadLetterQueue.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.maxSequences(0));
+    }
+
+    @Test
+    void buildWithNegativeMaxQueueSizeThrowsAxonConfigurationException() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builderTestSubject = MongoSequencedDeadLetterQueue.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.maxSequenceSize(-1));
+    }
+
+    @Test
+    void buildWithZeroMaxQueueSizeThrowsAxonConfigurationException() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builderTestSubject = MongoSequencedDeadLetterQueue.builder();
+
+        assertThrows(AxonConfigurationException.class, () -> builderTestSubject.maxSequenceSize(0));
+    }
+
+    @Test
+    void canNotSetProcessingGroupToEmpty() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.processingGroup("");
+        });
+    }
+
+    @Test
+    void canNotSetProcessingGroupToNull() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.processingGroup("");
+        });
+    }
+
+    @Test
+    void canNotSetMongoTemplateToNull() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.mongoTemplate(null);
+        });
+    }
+
+    @Test
+    void canNotSetConverterToNull() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.addConverter(null);
+        });
+    }
+
+    @Test
+    void canNotSetClaimDurationToNull() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.claimDuration(null);
+        });
+    }
+
+    @Test
+    void canNotSetTransactionManagerToNull() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue.builder();
+        assertThrows(AxonConfigurationException.class, () -> {
+            builder.transactionManager(null);
+        });
+    }
+
+    @Test
+    void canNotBuildWithoutProcessingGroup() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue
+                .builder()
+                .mongoTemplate(mongoTemplate)
+                .serializer(TestSerializer.JACKSON.getSerializer());
+        assertThrows(AxonConfigurationException.class, builder::build);
+    }
+
+    @Test
+    void canNotBuildWithoutSerializer() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue
+                .builder()
+                .processingGroup("my_processing_Group")
+                .mongoTemplate(mongoTemplate);
+        assertThrows(AxonConfigurationException.class, builder::build);
+    }
+
+    @Test
+    void canNotBuildWithoutMongoTemplate() {
+        MongoSequencedDeadLetterQueue.Builder<EventMessage<?>> builder = MongoSequencedDeadLetterQueue
+                .builder()
+                .processingGroup("my_processing_Group")
+                .serializer(TestSerializer.JACKSON.getSerializer());
+        assertThrows(AxonConfigurationException.class, builder::build);
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueueTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueueTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventhandling.deadletter;
+
+import com.mongodb.BasicDBObject;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.extensions.mongo.MongoTemplate;
+import org.axonframework.extensions.mongo.util.MongoTemplateFactory;
+import org.axonframework.extensions.mongo.utils.TestSerializer;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.messaging.deadletter.DeadLetter;
+import org.axonframework.messaging.deadletter.GenericDeadLetter;
+import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.axonframework.messaging.deadletter.SequencedDeadLetterQueueTest;
+import org.axonframework.messaging.deadletter.WrongDeadLetterTypeException;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Testcontainers
+class MongoSequencedDeadLetterQueueTest extends SequencedDeadLetterQueueTest<EventMessage<?>> {
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER = new MongoDBContainer("mongo:5");
+    private static final String PROCESSING_GROUP = "processing-group";
+    private static final int MAX_SEQUENCES_AND_SEQUENCE_SIZE = 128;
+
+    @Override
+    protected SequencedDeadLetterQueue<EventMessage<?>> buildTestSubject() {
+        MongoTemplate mongoTemplate = MongoTemplateFactory.build(
+                MONGO_CONTAINER.getHost(), MONGO_CONTAINER.getFirstMappedPort()
+        );
+        mongoTemplate.deadLetterCollection().deleteMany(new BasicDBObject());
+        return MongoSequencedDeadLetterQueue
+                .builder()
+                .processingGroup(PROCESSING_GROUP)
+                .maxSequences(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .maxSequenceSize(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .serializer(TestSerializer.xStreamSerializer())
+                .mongoTemplate(mongoTemplate)
+                .build();
+    }
+
+    @Override
+    protected long maxSequences() {
+        return MAX_SEQUENCES_AND_SEQUENCE_SIZE;
+    }
+
+    @Override
+    protected long maxSequenceSize() {
+        return MAX_SEQUENCES_AND_SEQUENCE_SIZE;
+    }
+
+    @Override
+    protected DeadLetter<EventMessage<?>> generateInitialLetter() {
+        return new GenericDeadLetter<>("sequenceIdentifier", generateEvent(), generateThrowable());
+    }
+
+    @Override
+    protected DeadLetter<EventMessage<?>> generateFollowUpLetter() {
+        return new GenericDeadLetter<>("sequenceIdentifier", generateEvent());
+    }
+
+    @Override
+    @SuppressWarnings("raw")
+    protected DeadLetter<EventMessage<?>> mapToQueueImplementation(DeadLetter<EventMessage<?>> deadLetter) {
+        if (deadLetter instanceof MongoDeadLetter) {
+            return deadLetter;
+        } else if (deadLetter instanceof GenericDeadLetter) {
+            return new MongoDeadLetter<>(0L, ((GenericDeadLetter<?>)deadLetter).getSequenceIdentifier().toString(), deadLetter.enqueuedAt(), deadLetter.lastTouched(), deadLetter.cause().orElse(null), deadLetter.diagnostics(), deadLetter.message());
+        } else {
+            throw new IllegalArgumentException("Can not map dead letter of type " + deadLetter.getClass().getName());
+        }
+    }
+
+    /**
+     * Only checking the epoch milli of timestamp as the rest is lost.
+     * @param expected the expected {@link DeadLetter}
+     * @param actual the actual {@link DeadLetter}
+     */
+    @Override
+    protected void assertLetter(DeadLetter<? extends EventMessage<?>> expected, DeadLetter<? extends EventMessage<?>> actual) {
+        Assertions.assertEquals(expected.message().getIdentifier(), actual.message().getIdentifier());
+        Assertions.assertEquals(expected.message().getTimestamp().toEpochMilli(), actual.message().getTimestamp().toEpochMilli());
+        Assertions.assertEquals(expected.message().getMetaData(), actual.message().getMetaData());
+        Assertions.assertEquals(expected.message().getPayload(), actual.message().getPayload());
+        Assertions.assertEquals(expected.message().getPayloadType(), actual.message().getPayloadType());
+        Assertions.assertEquals(expected.cause(), actual.cause());
+        Assertions.assertEquals(expected.enqueuedAt(), actual.enqueuedAt());
+        Assertions.assertEquals(expected.lastTouched(), actual.lastTouched());
+        Assertions.assertEquals(expected.diagnostics(), actual.diagnostics());
+    }
+
+    @Override
+    protected DeadLetter<EventMessage<?>> generateRequeuedLetter(DeadLetter<EventMessage<?>> original,
+                                                                 Instant lastTouched, Throwable requeueCause,
+                                                                 MetaData diagnostics) {
+        setAndGetTime(lastTouched);
+        return original.withCause(requeueCause)
+                       .withDiagnostics(diagnostics)
+                       .markTouched();
+    }
+
+    @Override
+    protected void setClock(Clock clock) {
+        GenericDeadLetter.clock = clock;
+    }
+
+    @Test
+    void cannotRequeueGenericDeadLetter() {
+        SequencedDeadLetterQueue<EventMessage<?>> queue = buildTestSubject();
+        DeadLetter<EventMessage<?>> letter = generateInitialLetter();
+        assertThrows(WrongDeadLetterTypeException.class, () -> {
+            queue.requeue(letter, d -> d);
+        });
+    }
+
+    @Test
+    void cannotEvictGenericDeadLetter() {
+        SequencedDeadLetterQueue<EventMessage<?>> queue = buildTestSubject();
+        DeadLetter<EventMessage<?>> letter = generateInitialLetter();
+        assertThrows(WrongDeadLetterTypeException.class, () -> {
+            queue.evict(letter);
+        });
+    }
+
+    @Test
+    void clearConvertorsShouldClearConvertors() {
+        MongoTemplate mongoTemplate = MongoTemplateFactory.build(
+                MONGO_CONTAINER.getHost(), MONGO_CONTAINER.getFirstMappedPort()
+        );
+        SequencedDeadLetterQueue<EventMessage<?>> testSubject = MongoSequencedDeadLetterQueue
+                .builder()
+                .processingGroup(PROCESSING_GROUP)
+                .maxSequences(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .maxSequenceSize(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .serializer(TestSerializer.xStreamSerializer())
+                .mongoTemplate(mongoTemplate)
+                .clearConverters()
+                .build();
+        DeadLetter<EventMessage<?>> letter = generateInitialLetter();
+        assertThrows(NoMongoConverterFoundException.class, () -> {
+            testSubject.enqueue("sequenceIdentifier", letter);
+        });
+    }
+}

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/documentperevent/EventEntryTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/documentperevent/EventEntryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.eventsourcing.eventstore.documentperevent;
+
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.serialization.TestSerializer;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventEntryTest {
+
+    @Test
+    void equalsHashcodeAndToStringShouldWorkCorrectly() {
+        EventEntry original = testEntry();
+        EventEntry copy = new EventEntry(original.asDocument(EventEntryConfiguration.getDefault()),
+                                         EventEntryConfiguration.getDefault());
+        assertEquals(original, copy);
+        assertEquals(original.hashCode(), copy.hashCode());
+        assertEquals(original.toString(), copy.toString());
+    }
+
+    static EventEntry testEntry() {
+        return new EventEntry(
+                new GenericDomainEventMessage<>(null, null, 0L, "foo"),
+                TestSerializer.JACKSON.getSerializer()
+        );
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/AxonFramework/extension-mongo/issues/270

A lot was copied from the JPA implementation, with the entries and query code changed to fit Mongo.
This does include transactions with the `NoTransactionManager` as default.