### PR TITLE
[#280] Implement transaction support

### DIFF
--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/saga/repository/MongoSagaStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventhandling/saga/repository/MongoSagaStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.axonframework.extensions.mongo.eventhandling.saga.repository;
 
 import com.mongodb.client.FindIterable;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.extensions.mongo.MongoTemplate;
 import org.axonframework.extensions.mongo.util.MongoTemplateFactory;
 import org.axonframework.extensions.mongo.utils.TestSerializer;
@@ -250,6 +251,12 @@ class MongoSagaStoreTest {
         testSubject.deleteSaga(MyTestSaga.class, identifier, singleton(associationValue));
 
         assertNull(mongoTemplate.sagaCollection().find(SagaEntry.queryByIdentifier(identifier)).first());
+    }
+
+    @Test
+    void shouldThrowWhenTransactionManagerNull() {
+        MongoSagaStore.Builder builder = MongoSagaStore.builder();
+        assertThrows(AxonConfigurationException.class, () -> builder.transactionManager(null));
     }
 
     private static class MyTestSaga {

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/eventstore/MongoEventStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.axonframework.extensions.mongo.eventsourcing.eventstore;
 
 import com.mongodb.BasicDBObject;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.TrackingToken;
@@ -111,6 +112,12 @@ class MongoEventStorageEngineTest extends AbstractMongoEventStorageEngineTest {
         List<EventMessage<?>> readEvents = testSubject.readEvents(result, false).collect(toList());
 
         assertEventStreamsById(Arrays.asList(event1, event3, event2), readEvents);
+    }
+
+    @Test
+    void settingNullTransactionManagerShouldThrow() {
+        MongoEventStorageEngine.Builder builder = MongoEventStorageEngine.builder();
+        assertThrows(AxonConfigurationException.class, () -> builder.transactionManager(null));
     }
 
     @Override

--- a/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
+++ b/mongo/src/test/java/org/axonframework/extensions/mongo/eventsourcing/tokenstore/MongoTokenStoreTest.java
@@ -20,6 +20,7 @@ import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.thoughtworks.xstream.XStream;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.GlobalSequenceTrackingToken;
 import org.axonframework.eventhandling.Segment;
 import org.axonframework.eventhandling.TrackingToken;
@@ -528,6 +529,12 @@ class MongoTokenStoreTest {
                     tokenStoreDifferentOwner.initializeSegment(initialToken, testProcessorName, testSegment);
                     return true;
                 });
+    }
+
+    @Test
+    void settingNullTransactionManagerShouldThrow() {
+        MongoTokenStore.Builder builder = MongoTokenStore.builder();
+        assertThrows(AxonConfigurationException.class, () -> builder.transactionManager(null));
     }
 
     private <T> T testConcurrency(Supplier<T> s1, Supplier<T> s2) throws InterruptedException {


### PR DESCRIPTION
Resolves #280.
This pull request adds a Mongo-specific `TransactionManager` and uses it in the three classes reading and writing to Mongo.