### PR TITLE
Don't use transactions over the iterators to get all the dead letter.

### DIFF
--- a/axon-mongo-spring/pom.xml
+++ b/axon-mongo-spring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2022. Axon Framework
+  ~ Copyright (c) 2010-2023. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -53,6 +53,18 @@
                     <artifactId>mongodb-driver-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+            <version>${axon.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/axon-mongo-spring/src/test/java/org/axonframework/extensions/mongo/spring/MongoDeadLetteringWithTransActionsIntegrationTest.java
+++ b/axon-mongo-spring/src/test/java/org/axonframework/extensions/mongo/spring/MongoDeadLetteringWithTransActionsIntegrationTest.java
@@ -31,7 +31,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-public class MongoDeadLetteringWithTransActionsIntegrationTest extends DeadLetteringEventIntegrationTest {
+class MongoDeadLetteringWithTransactionsIntegrationTest extends DeadLetteringEventIntegrationTest {
 
     @Container
     private static final MongoDBContainer MONGO_CONTAINER = new MongoDBContainer("mongo:5");

--- a/axon-mongo-spring/src/test/java/org/axonframework/extensions/mongo/spring/MongoDeadLetteringWithTransActionsIntegrationTest.java
+++ b/axon-mongo-spring/src/test/java/org/axonframework/extensions/mongo/spring/MongoDeadLetteringWithTransActionsIntegrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.spring;
+
+import com.mongodb.BasicDBObject;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.deadletter.DeadLetteringEventIntegrationTest;
+import org.axonframework.extensions.mongo.MongoTemplate;
+import org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue;
+import org.axonframework.extensions.mongo.utils.TestSerializer;
+import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class MongoDeadLetteringWithTransActionsIntegrationTest extends DeadLetteringEventIntegrationTest {
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER = new MongoDBContainer("mongo:5");
+    private static final String PROCESSING_GROUP = "processing-group";
+    private static final int MAX_SEQUENCES_AND_SEQUENCE_SIZE = 128;
+
+    @Override
+    protected SequencedDeadLetterQueue<EventMessage<?>> buildDeadLetterQueue() {
+        String connectionString =
+                "mongodb://" + MONGO_CONTAINER.getHost() + ":" + MONGO_CONTAINER.getFirstMappedPort() + "/dit";
+        MongoDatabaseFactory factory = new SimpleMongoClientDatabaseFactory(connectionString);
+        MongoTemplate mongoTemplate = SpringMongoTemplate.builder().factory(factory).build();
+        mongoTemplate.deadLetterCollection().deleteMany(new BasicDBObject());
+        return MongoSequencedDeadLetterQueue
+                .builder()
+                .processingGroup(PROCESSING_GROUP)
+                .maxSequences(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .maxSequenceSize(MAX_SEQUENCES_AND_SEQUENCE_SIZE)
+                .serializer(TestSerializer.xStreamSerializer())
+                .mongoTemplate(mongoTemplate)
+                .transactionManager(new SpringMongoTransactionManager(new MongoTransactionManager(factory)))
+                .build();
+    }
+}

--- a/axon-mongo-spring/src/test/java/org/axonframework/extensions/mongo/utils/TestSerializer.java
+++ b/axon-mongo-spring/src/test/java/org/axonframework/extensions/mongo/utils/TestSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.utils;
+
+import com.thoughtworks.xstream.XStream;
+import org.axonframework.extensions.mongo.serialization.DBObjectXStreamSerializer;
+import org.axonframework.serialization.xml.CompactDriver;
+import org.axonframework.serialization.xml.XStreamSerializer;
+
+/**
+ * Utility providing {@link org.axonframework.serialization.Serializer} instances for testing.
+ *
+ * @author Steven van Beelen
+ */
+public abstract class TestSerializer {
+
+    private TestSerializer() {
+        // Test utility class
+    }
+
+    /**
+     * Return a {@link XStreamSerializer} using a default {@link XStream} instance with a {@link CompactDriver}.
+     *
+     * @return a {@link XStreamSerializer} using a default {@link XStream} instance with a {@link CompactDriver}
+     */
+    public static XStreamSerializer xStreamSerializer() {
+        return XStreamSerializer.builder()
+                                .xStream(new XStream(new CompactDriver()))
+                                .build();
+    }
+
+    /**
+     * Return a {@link DBObjectXStreamSerializer} using a default {@link XStream} instance.
+     *
+     * @return a {@link DBObjectXStreamSerializer} using a default {@link XStream} instance
+     */
+    public static DBObjectXStreamSerializer dbObjectXStreamSerializer() {
+        return DBObjectXStreamSerializer.builder()
+                                        .xStream(new XStream())
+                                        .build();
+    }
+}

--- a/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueue.java
+++ b/mongo/src/main/java/org/axonframework/extensions/mongo/eventhandling/deadletter/MongoSequencedDeadLetterQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -281,25 +281,21 @@ public class MongoSequencedDeadLetterQueue<M extends EventMessage<?>> implements
     @Override
     public Iterable<DeadLetter<? extends M>> deadLetterSequence(@Nonnull Object sequenceIdentifier) {
         String stringSequenceIdentifier = toStringSequenceIdentifier(sequenceIdentifier);
-        return transactionManager.fetchInTransaction(
-                () -> mongoTemplate.deadLetterCollection()
-                                   .find(processingGroupAndSequenceIdentifierFilter(processingGroup,
-                                                                                    stringSequenceIdentifier))
-                                   .sort(indexSortAscending())
-                                   .map(DeadLetterEntry::new)
-                                   .map(this::toLetter)
-        );
+        return mongoTemplate.deadLetterCollection()
+                            .find(processingGroupAndSequenceIdentifierFilter(processingGroup,
+                                                                             stringSequenceIdentifier))
+                            .sort(indexSortAscending())
+                            .map(DeadLetterEntry::new)
+                            .map(this::toLetter);
     }
 
     @Override
     public Iterable<Iterable<DeadLetter<? extends M>>> deadLetters() {
-        return transactionManager.fetchInTransaction(
-                () -> sequenceIdentifierIterator(mongoTemplate.deadLetterCollection(), processingGroup)
-                        .map(sequenceIdentifier -> {
-                            assertNonNull(sequenceIdentifier, "SequenceIdentifier can not be null.");
-                            return deadLetterSequence(sequenceIdentifier);
-                        })
-        );
+        return sequenceIdentifierIterator(mongoTemplate.deadLetterCollection(), processingGroup)
+                .map(sequenceIdentifier -> {
+                    assertNonNull(sequenceIdentifier, "SequenceIdentifier can not be null.");
+                    return deadLetterSequence(sequenceIdentifier);
+                });
     }
 
     /**


### PR DESCRIPTION
It turned out when using dead letters together with transactions was causing errors when trying to retrieve the dead letters. This pr removes the use of the transaction manager when the iterators are gotten from Mongo, fixing the problem. It also adds the integration tests for this case, which initially did fail with the same `state should be: open` error encountered from running it in an application.