### PR TITLE
Set default sequenced dead letter queue provider.

### DIFF
--- a/axon-mongo-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/mongo/springboot/AxonMongoProperties.java
+++ b/axon-mongo-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/mongo/springboot/AxonMongoProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,11 @@ public class AxonMongoProperties {
      * The AutoConfiguration settings for the token store
      */
     private TokenStore tokenStore = new TokenStore();
+
+    /**
+     * The AutoConfiguration settings for event handling related to this extension
+     */
+    private EventHandling eventHandling = new EventHandling();
 
     /**
      * The AutoConfiguration settings for the event store
@@ -84,6 +89,24 @@ public class AxonMongoProperties {
      */
     public void setTokenStore(TokenStore tokenStore) {
         this.tokenStore = tokenStore;
+    }
+
+    /**
+     * Retrieves the AutoConfiguration settings related to event handling.
+     *
+     * @return the AutoConfiguration settings related to event handling.
+     */
+    public EventHandling getEventHandling() {
+        return eventHandling;
+    }
+
+    /**
+     * Defines the AutoConfiguration settings related to event handling.
+     *
+     * @param eventHandling the AutoConfiguration settings for the token store.
+     */
+    public void setEventHandling(EventHandling eventHandling) {
+        this.eventHandling = eventHandling;
     }
 
     /**
@@ -148,6 +171,38 @@ public class AxonMongoProperties {
          */
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+    }
+
+    public static class EventHandling {
+
+        /**
+         * Enables setting the
+         * {@link org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue} as the
+         * default {@link org.axonframework.messaging.deadletter.SequencedDeadLetterQueue}. Defaults to "true".
+         */
+        private boolean dlqEnabled = true;
+
+        /**
+         * Indicates whether setting a
+         * {@link org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue} as default
+         * sequenced dead letter queue is enabled.
+         *
+         * @return true if creating the token store is enabled, false if otherwise
+         */
+        public boolean isDlqEnabled() {
+            return dlqEnabled;
+        }
+
+        /**
+         * Enables (if {@code true}, default) or disables (if {@code false}) setting a *
+         * {@link org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue} as default
+         * sequenced dead letter queue.
+         *
+         * @param dlqEnabled whether to enable setting a default for the sequenced dead letter queue.
+         */
+        public void setDlqEnabled(boolean dlqEnabled) {
+            this.dlqEnabled = dlqEnabled;
         }
     }
 

--- a/axon-mongo-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/mongo/springboot/AxonMongoProperties.java
+++ b/axon-mongo-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/mongo/springboot/AxonMongoProperties.java
@@ -186,20 +186,20 @@ public class AxonMongoProperties {
         /**
          * Indicates whether setting a
          * {@link org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue} as default
-         * sequenced dead letter queue is enabled.
+         * sequenced dead-letter queue is enabled.
          *
-         * @return true if creating the token store is enabled, false if otherwise
+         * @return {@code true} if creating the sequenced dead-letter queue is enabled, {@code false} otherwise.
          */
         public boolean isDlqEnabled() {
             return dlqEnabled;
         }
 
         /**
-         * Enables (if {@code true}, default) or disables (if {@code false}) setting a *
+         * Enables (if {@code true}, default) or disables (if {@code false}) setting a
          * {@link org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue} as default
          * sequenced dead letter queue.
          *
-         * @param dlqEnabled whether to enable setting a default for the sequenced dead letter queue.
+         * @param dlqEnabled Whether to enable setting a default for the sequenced dead-letter queue.
          */
         public void setDlqEnabled(boolean dlqEnabled) {
             this.dlqEnabled = dlqEnabled;

--- a/axon-mongo-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/mongo/springboot/autoconfig/MongoDeadLetterProviderAutoConfiguration.java
+++ b/axon-mongo-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/mongo/springboot/autoconfig/MongoDeadLetterProviderAutoConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.mongo.springboot.autoconfig;
+
+import org.axonframework.common.transaction.TransactionManager;
+import org.axonframework.config.EventProcessingModule;
+import org.axonframework.extensions.mongo.MongoTemplate;
+import org.axonframework.extensions.mongo.eventhandling.deadletter.MongoSequencedDeadLetterQueue;
+import org.axonframework.extensions.mongo.springboot.AxonMongoProperties;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.springboot.EventProcessorProperties;
+import org.axonframework.springboot.autoconfig.EventProcessingAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import java.util.Optional;
+
+@AutoConfiguration
+@EnableConfigurationProperties(value = {AxonMongoProperties.class, EventProcessorProperties.class})
+@AutoConfigureAfter(value = {MongoAutoConfiguration.class, EventProcessingAutoConfiguration.class})
+public class MongoDeadLetterProviderAutoConfiguration {
+
+    private final AxonMongoProperties axonMongoProperties;
+    private final EventProcessorProperties eventProcessorProperties;
+
+    public MongoDeadLetterProviderAutoConfiguration(
+            AxonMongoProperties axonMongoProperties,
+            EventProcessorProperties eventProcessorProperties
+    ) {
+        this.axonMongoProperties = axonMongoProperties;
+        this.eventProcessorProperties = eventProcessorProperties;
+    }
+
+    @Autowired
+    void registerDeadLetterProvider(
+            EventProcessingModule processingModule,
+            MongoTemplate mongoTemplate,
+            Serializer serializer,
+            TransactionManager transactionManager
+    ) {
+        if (!axonMongoProperties.getEventHandling().isDlqEnabled()) {
+            return;
+        }
+        processingModule.registerDeadLetterQueueProvider(
+                processingGroup -> {
+                    if (dlqEnabled(processingGroup)) {
+                        return configuration -> MongoSequencedDeadLetterQueue
+                                .builder()
+                                .processingGroup(processingGroup)
+                                .mongoTemplate(mongoTemplate)
+                                .transactionManager(transactionManager)
+                                .serializer(serializer)
+                                .build();
+                    } else {
+                        return null;
+                    }
+                });
+    }
+
+    private boolean dlqEnabled(String processingGroup) {
+        return Optional.ofNullable(eventProcessorProperties.getProcessors().get(processingGroup))
+                       .map(processorSettings -> processorSettings.getDlq().isEnabled())
+                       .orElse(false);
+    }
+}

--- a/axon-mongo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/axon-mongo-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.axonframework.extensions.mongo.springboot.autoconfig.MongoAutoConfiguration
+  org.axonframework.extensions.mongo.springboot.autoconfig.MongoAutoConfiguration,\
+  org.axonframework.extensions.mongo.springboot.autoconfig.MongoDeadLetterProviderAutoConfiguration

--- a/axon-mongo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/axon-mongo-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.axonframework.extensions.mongo.springboot.autoconfig.MongoAutoConfiguration
+org.axonframework.extensions.mongo.springboot.autoconfig.MongoDeadLetterProviderAutoConfiguration


### PR DESCRIPTION
Set default sequenced dead letter queue provider, but allow disabling by setting the `axon.mongo.event-handling.dlq-enabled` property.