### PR TITLE
Move old docs 2 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ will be a lot worse compared to Axon Server.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io) contains a separate chapter for all the extensions.
-The Mongo extension description can be found [here](https://docs.axoniq.io/reference-guide/extensions/mongo).
-This extension should be regarded as a partial replacement
-of [Axon Server](https://axoniq.io/product-overview/axon-server),
+The [AxonIQ Library](https://library.axoniq.io) contains a section for the guides of all the Axon Framework extensions.
+The MongoDB extension guide can be found [here](https://library.axoniq.io/home/guides/axon-framework.html).
+
+This extension should be regarded as a partial replacement of [Axon Server](https://axoniq.io/product-overview/axon-server),
 since it only cover the event storage part.
 
 ## Receiving help
@@ -39,10 +39,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/mongo) should be your first stop,
- as the majority of possible scenarios you might encounter when using Axon should be covered there.
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
+  as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
- we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us. 
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently answer your question.
 Axon Framework and Server developers will help out on a best effort basis.
 Know that any support from contributors on posted question is very much appreciated on the forum.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.vscode
+vale
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,24 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+AxonIQ.AcronymCase = NO
+AxonIQ.HeadingTitle = NO

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: MongoDB Extension docs PREVIEW
+  start_page: mongodb_extension_old_ref::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.10/ui-bundle.zip

--- a/docs/old-reference-guide/antora.yml
+++ b/docs/old-reference-guide/antora.yml
@@ -1,0 +1,14 @@
+name: mongodb_extension_old_ref
+title: MongoDB Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The MongoDB Extension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/old-reference-guide/modules/ROOT/pages/dlq-spring-config.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/dlq-spring-config.adoc
@@ -1,0 +1,29 @@
+:navtitle: Configuration of the MongoDB Dead-Letter Queue with Spring
+= Configuration of the MongoDB Dead-Letter Queue with Spring
+
+See xref:axon_framework_old_ref:events:event-processors/README.adoc#dead-letter-queue[Dead-Letter Queue] for the general information about the Dead-Letter Queue.
+
+[source,java]
+----
+@Configuration
+public class AxonConfig {
+  // omitting other configuration methods...
+  @Bean
+  public ConfigurerModule deadLetterQueueConfigurerModule(
+          MongoTemplate mongoTemplate
+  ) {
+    // Replace "my-processing-group" for the processing group you want to configure the DLQ on.
+    return configurer -> configurer.eventProcessing().registerDeadLetterQueue(
+            "my-processing-group",
+            config -> MongoSequencedDeadLetterQueue.builder()
+                                                 .processingGroup("my-processing-group")
+                                                 .maxSequences(256)
+                                                 .maxSequenceSize(256)
+                                                 .mongoTemplate(mongoTemplate)
+                                                 .transactionManager(config.getComponent(TransactionManager.class))
+                                                 .serializer(config.serializer())
+                                                 .build()
+    );
+  }
+}
+----

--- a/docs/old-reference-guide/modules/ROOT/pages/index.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/index.adoc
@@ -1,2 +1,24 @@
 :navtitle: MongoDB Extension
 = MongoDB Extension
+
+The `MongoEventStorageEngine` has an `@PostConstruct` annotated method, called `ensureIndexes` which will generate the indexes required for correct operation. That means, when running in a container that automatically calls `@PostConstruct` handlers, the required unique index on "Aggregate Identifier" and "Event Sequence Number" is created when the event store is created.
+
+Note that there is always a balance between query optimization and update speed. Load testing is ultimately the best way to discover which indices provide the best performance.
+
+== Normal operation use
+
+An index is automatically created on `"aggregateIdentifier"`, `"type"` and `"sequenceNumber"` in the domain events (default name: `"domainevents"`) collection. Additionally, a non-unique index on `"timestamp"` and `"sequenceNumber"` is configured on the domain events (default name: `"domainevents"`) collection, for tracking event processors.
+
+== Snapshotting
+
+A (unique) index on `"aggregateIdentifier"` and `"sequenceNumber"` is automatically created in the snapshot events (default name: `"snapshotevents"`) collection.
+
+== Sagas
+
+Put a (unique) index on the `"sagaIdentifier"` in the saga (default name: `"sagas"`) collection. Put an index on the `"sagaType"`, `"associations.key"` and `"associations.value"` properties in the saga (default name: `"sagas"`) collection.
+
+== Dead letter queue
+
+Put a (unique) index on the combination of `"processingGroup"`, `"sequenceIdentifier"` and `"index"` in the dead letter (default name: `"deadletters"`) collection. Put an index on the `"processingGroup"`, and `"sequenceIdentifier"` properties in the dead letter (default name: `"deadletters"`) collection. Put an index on the `"processingGroup"` property in the dead letter (default name: `"deadletters"`) collection.
+
+NOTE:  In pre Axon Framework 3 release we found MongoDb to be a good fit as an Event Store. However, with the introduction of Tracking Event Processors and how they track their events, we have encountered some inefficiencies regarding the Mongo Event Store implementation. We recommend using a built-for-purpose event store like xref:axon_server_ref:ROOT:index.adoc[Axon Server], or alternatively an RDBMS based (the JPA or JDBC implementations for example), and would only suggest to use Mongo for this use case if you have found its performance to be beneficial for your application.

--- a/docs/old-reference-guide/modules/ROOT/pages/index.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,2 @@
+:navtitle: MongoDB Extension
+= MongoDB Extension

--- a/docs/old-reference-guide/modules/ROOT/pages/spring-config.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/spring-config.adoc
@@ -1,0 +1,35 @@
+:navtitle: Configuration of the Event Store with Spring
+= Configuration of the Event Store with Spring
+
+[source,java]
+----
+@Configuration
+public class AxonConfig {
+    // omitting other configuration methods...
+
+    // The EmbeddedEventStore delegates actual storage and retrieval of events to an EventStorageEngine.
+    @Bean
+    public EventStore eventStore(EventStorageEngine storageEngine,
+                                 GlobalMetricRegistry metricRegistry) {
+        return EmbeddedEventStore.builder()
+                                 .storageEngine(storageEngine)
+                                 .messageMonitor(metricRegistry.registerEventBus("eventStore"))
+                                 .spanFactory(spanFactory)
+                                 // ...
+                                 .build();
+    }
+
+    // The MongoEventStorageEngine stores each event in a separate MongoDB document.
+    @Bean
+    public EventStorageEngine storageEngine(MongoDatabaseFactory factory,
+                                            TransactionManager transactionManager) {
+        return MongoEventStorageEngine.builder()
+                                      .mongoTemplate(SpringMongoTemplate.builder()
+                                                                        .factory(factory)
+                                                                        .build())
+                                      .transactionManager(transactionManager)
+                                      // ...
+                                      .build();
+    }
+}
+----

--- a/docs/old-reference-guide/modules/ROOT/pages/springboot-config.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/springboot-config.adoc
@@ -1,0 +1,36 @@
+:navtitle: Configuration in SpringBoot
+= Configuration in SpringBoot
+
+This extension can be added as a Spring Boot starter dependency to your project using group id `org.axonframework.extensions.mongo` and artifact id `axon-mongo-spring-boot-starter`. When using the autoconfiguration, by default the following components will be created for you automatically:
+
+- A `MongoTransactionManager` to enable transactions with Mongo.
+
+- A `SpringMongoTransactionManager`, this is the wrapped Spring mongo transaction manager, and will also be injected where applicable in other components created by the auto-config.
+
+- A `SpringMongoTemplate`, this will use a `MongoDatabaseFactory` that should be available. To use transaction with Mongo the collections need to be accessed in a certain way, and this component makes sure of that.
+
+- A `MongoTokenStore`, this will be used by the event processors to can keep track which events have been processed, and which segments are claimed.
+
+- A `MongoSagaStore`, this will be used to store and retrieve saga's.
+
+It's also possible to autoconfigure the `StorageStrategy` and `EventStorageEngine` by setting the `mongo.event-store.enabled` to true. The creation of the token store and the saga store can be turned off by setting `mongo.token-store.enabled` or `mongo.saga-store.enabled` to `false`. It's also possible to use a different database for the axon collections than the default the `MongoDatabaseFactory` uses by setting the `axon.mongo.database-name` property.
+
+The relevant configuration could look like this:
+
+[source,yaml]
+----
+spring:
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/test
+  mongo:
+    database-name: axon
+    token-store:
+      enabled: true
+    saga-store:
+      enabled: false
+    event-store:
+      enabled: false
+----
+
+While `test` is the default database name, for the Axon collections the `axon` database will be used instead. The saga store will not be initialised.

--- a/docs/old-reference-guide/modules/nav.adoc
+++ b/docs/old-reference-guide/modules/nav.adoc
@@ -1,0 +1,1 @@
+* xref:ROOT:index.adoc[]

--- a/docs/old-reference-guide/modules/nav.adoc
+++ b/docs/old-reference-guide/modules/nav.adoc
@@ -1,1 +1,4 @@
 * xref:ROOT:index.adoc[]
+** xref:ROOT:spring-config.adoc[]
+** xref:ROOT:springboot-config.adoc[]
+** xref:ROOT:dlq-spring-config.adoc[]


### PR DESCRIPTION
Contents from the Extensions section for Mongo Extension in the old reference guide has been moved here to be published with antora to library.axoniq.io > Guides > Axon framework